### PR TITLE
Add pirate adventure example in Ink + metadata

### DIFF
--- a/dsl/examples/pirate-adventure/metadata.json
+++ b/dsl/examples/pirate-adventure/metadata.json
@@ -1,0 +1,69 @@
+{
+  "scenes": {
+    "beach": {
+      "description": "A sandy beach with palm trees and a wrecked ship",
+      "background_color": "#c2b280",
+      "hotspots": [
+        {
+          "id": "ship",
+          "label": "Ship",
+          "x": 0.6,
+          "y": 0.4,
+          "width": 0.25,
+          "height": 0.3,
+          "ink_target": "beach_ship"
+        },
+        {
+          "id": "palms",
+          "label": "Palm Trees",
+          "x": 0.15,
+          "y": 0.3,
+          "width": 0.15,
+          "height": 0.4,
+          "ink_target": "beach_palms"
+        }
+      ],
+      "characters": [],
+      "exits": [
+        {"direction": "north", "target_scene": "cave", "requires": "has_key", "x": 0.5, "y": 0.05},
+        {"direction": "east", "target_scene": "village", "x": 0.95, "y": 0.5}
+      ]
+    },
+    "cave": {
+      "description": "A dark cave with dripping water and a treasure chest",
+      "background_color": "#2d2d2d",
+      "hotspots": [
+        {
+          "id": "chest",
+          "label": "Chest",
+          "x": 0.7,
+          "y": 0.6,
+          "width": 0.15,
+          "height": 0.15,
+          "ink_target": "cave_chest"
+        }
+      ],
+      "characters": [],
+      "exits": [
+        {"direction": "south", "target_scene": "beach", "x": 0.5, "y": 0.95}
+      ]
+    },
+    "village": {
+      "description": "A small fishing village with an old sailor",
+      "background_color": "#8fbc8f",
+      "hotspots": [],
+      "characters": [
+        {
+          "id": "sailor",
+          "label": "Old Sailor",
+          "x": 0.4,
+          "y": 0.5,
+          "ink_target": "village_sailor"
+        }
+      ],
+      "exits": [
+        {"direction": "west", "target_scene": "beach", "x": 0.05, "y": 0.5}
+      ]
+    }
+  }
+}

--- a/dsl/examples/pirate-adventure/story.ink
+++ b/dsl/examples/pirate-adventure/story.ink
@@ -1,0 +1,50 @@
+VAR has_rope = false
+VAR has_key = false
+
+-> beach
+
+=== beach ===
+You stand on a sandy beach. A wrecked ship leans against the rocks. Palm trees sway in the wind.
+
++ [Look at the ship] -> beach_ship
++ [Look at the palm trees] -> beach_palms
++ {has_key} [Go north to the cave] -> cave
++ [Go east to the village] -> village
+
+= beach_ship
+The ship's hull is cracked open. Inside you spot a coil of rope.
++ [Take the rope]
+  ~ has_rope = true
+  You grab the rope. Could be useful.
+  -> beach
++ [Leave it] -> beach
+
+= beach_palms
+Tall palm trees with coconuts. Nothing special, but the shade is nice.
+-> beach
+
+=== cave ===
+A dark cave. Water drips from the ceiling. You see a chest in the corner.
+
++ [Look at the chest] -> cave_chest
++ [Go south to the beach] -> beach
+
+= cave_chest
+{has_rope:
+  You tie the rope to the chest and pull it open. Gold coins spill everywhere! You've found Blackbeard's treasure!
+  -> END
+- else:
+  The chest is wedged tight. You need something to pull it open.
+  -> cave
+}
+
+=== village ===
+A small fishing village. An old sailor sits on a barrel, muttering to himself.
+
++ [Talk to the sailor] -> village_sailor
++ [Go west to the beach] -> beach
+
+= village_sailor
+"Arrr, looking for the cave, are ye? You'll need the key. I dropped it somewhere on the beach... near the ship, I think."
+~ has_key = true
+-> village


### PR DESCRIPTION
## Summary
Closes #11

Adds the reference pirate adventure example with 3 scenes (beach, cave, village), inventory items, NPC dialogue, and a win condition.

## Changes
- `dsl/examples/pirate-adventure/story.ink` — complete Ink script
- `dsl/examples/pirate-adventure/metadata.json` — scene metadata for Phaser

## Test Plan
- Verify ink_target references in metadata match Ink knot/stitch names
- Verify scene names in exits match knot names