### PR TITLE
Fyso tenant setup: Adventure entity, rules, and API client

### DIFF
--- a/docs/superpowers/specs/2026-03-28-fyso-tenant-setup.md
+++ b/docs/superpowers/specs/2026-03-28-fyso-tenant-setup.md
@@ -1,0 +1,108 @@
+# Fyso Tenant Setup — VerbEngine
+
+**Date**: 2026-03-28
+**Issue**: #10
+
+## Overview
+
+Fyso backend configuration for VerbEngine MVP. This document records the entity, rules, and API setup.
+
+## Adventure Entity
+
+**Name**: `adventures`
+**Description**: AI-generated point-and-click adventures.
+
+### Fields
+
+| Field | Key | Type | Required | Description |
+|-------|-----|------|----------|-------------|
+| Title | `title` | text | yes | Adventure title |
+| Prompt | `prompt` | textarea | yes | User prompt describing the adventure |
+| Scenes Count | `scenes_count` | number | no | Number of scenes |
+| Ink Script | `ink_script` | textarea | no | Generated Ink script |
+| Scene Metadata | `scene_metadata` | textarea | no | JSON with scene definitions |
+| Status | `status` | select | yes | generating / ready / error |
+
+## API Endpoints (auto-generated)
+
+Base URL: `https://api.fyso.dev`
+
+| Operation | Method | Path |
+|-----------|--------|------|
+| List adventures | GET | `/api/entities/adventures/records` |
+| Get adventure | GET | `/api/entities/adventures/records/{id}` |
+| Create adventure | POST | `/api/entities/adventures/records` |
+| Update adventure | PUT | `/api/entities/adventures/records/{id}` |
+| Delete adventure | DELETE | `/api/entities/adventures/records/{id}` |
+
+Authentication: `Authorization: Bearer {apiKey}` or `X-API-Key: {apiKey}`
+
+## Business Rules
+
+### 1. Set Generating Status (before_save)
+
+- **ID**: `96cf3de4-9c0c-4e2d-b6bb-72f4ba727a04`
+- **Trigger**: before_save, when `prompt` field changes
+- **Action**: Sets `status` to `"generating"`
+- **Priority**: 5
+
+### 2. Generate Adventure (after_save)
+
+- **ID**: `8f651f24-6abd-40f8-9334-f376a6d7ff8e`
+- **Trigger**: after_save, when `status == "generating"`
+- **Actions**:
+  1. Calls LLM with adventure generation prompt
+  2. Extracts Ink script from `ink` code block in response
+  3. Extracts scene metadata JSON from `json` code block in response
+  4. Maps results to `ink_script` and `scene_metadata` fields
+
+### LLM Prompt Summary
+
+The AI rule instructs the LLM to generate:
+1. A complete Ink script with scene tags (`# SCENE`, `# BACKGROUND`), hotspot tags (`# HOTSPOT`, `# ITEM_PICKUP`, `# REQUIRES_ITEM`, `# EXIT`)
+2. A scene metadata JSON with coordinates in 320x200 resolution
+
+## API Key
+
+- **Name**: `verbengine-frontend`
+- **Key prefix**: `fyso_pkey_bc5776`
+- Store securely in environment variable `FYSO_API_KEY`
+
+## TypeScript Client
+
+Generated client saved at: `src/api/fyso-client.ts`
+
+Usage:
+```typescript
+import { FysoClient } from './api/fyso-client';
+
+const client = new FysoClient({
+  baseUrl: 'https://api.fyso.dev',
+  apiKey: import.meta.env.VITE_FYSO_API_KEY,
+});
+
+// Create adventure (triggers AI generation)
+const adventure = await client.adventures.create({
+  title: 'My Adventure',
+  prompt: 'A pirate adventure on a desert island...',
+  status: 'generating',
+});
+
+// Poll for completion
+const result = await client.adventures.get(adventure.id);
+// result.status === 'ready' when generation is complete
+```
+
+## Known Issue
+
+The AI provider (OpenAI) is configured in the tenant but the API key appears to be invalid or expired. The `ai_call` rule action returns "No AI provider configured for this tenant" during dry-run tests. A valid OpenAI API key needs to be set via:
+
+```
+fyso_ai configure_provider with a valid api_key
+```
+
+Once the AI provider is working, the full flow will be:
+1. Frontend calls `POST /api/entities/adventures/records` with title + prompt
+2. before_save rule sets status = "generating"
+3. after_save rule calls LLM, extracts ink_script + scene_metadata
+4. Record updated with generated content and status = "ready"

--- a/src/api/fyso-client.ts
+++ b/src/api/fyso-client.ts
@@ -1,0 +1,149 @@
+// Auto-generated Fyso API Client
+// Generated at: 2026-03-28
+// Framework: fetch
+// Do not edit manually — regenerate with: fyso_meta api_client
+
+// ============= Types =============
+
+export interface ListParams {
+  page?: number;
+  limit?: number;
+  sort?: string;
+  order?: 'asc' | 'desc';
+  search?: string;
+  resolve?: boolean;
+  [key: `filter.${string}`]: string | undefined;
+}
+
+export interface PaginatedResponse<T> {
+  items: T[];
+  total: number;
+  page: number;
+  limit: number;
+  totalPages: number;
+}
+
+export interface ApiError {
+  code: string;
+  message: string;
+}
+
+export class FysoApiError extends Error {
+  constructor(public code: string, message: string) {
+    super(message);
+    this.name = 'FysoApiError';
+  }
+}
+
+/**
+ * Adventures
+ * AI-generated point-and-click adventures. Each adventure has an Ink script,
+ * scene metadata JSON, and generation status.
+ */
+export interface Adventure {
+  id: string;
+  title: string;
+  prompt: string;
+  scenes_count?: number;
+  ink_script?: string;
+  scene_metadata?: string;
+  status: 'generating' | 'ready' | 'error';
+  created_at: string;
+  updated_at: string;
+}
+
+export interface CreateAdventure {
+  title: string;
+  prompt: string;
+  scenes_count?: number;
+  ink_script?: string;
+  scene_metadata?: string;
+  status?: 'generating' | 'ready' | 'error';
+}
+
+export type UpdateAdventure = Partial<CreateAdventure>;
+
+// ============= Client =============
+
+export interface FysoConfig {
+  baseUrl: string;
+  apiKey: string;
+}
+
+export class FysoClient {
+  private config: FysoConfig;
+
+  constructor(config: FysoConfig) {
+    this.config = config;
+  }
+
+  private async request<T>(
+    method: string,
+    path: string,
+    body?: unknown
+  ): Promise<T> {
+    const url = `${this.config.baseUrl}${path}`;
+
+    const res = await fetch(url, {
+      method,
+      headers: {
+        'Authorization': `Bearer ${this.config.apiKey}`,
+        'Content-Type': 'application/json',
+      },
+      body: body ? JSON.stringify(body) : undefined,
+    });
+
+    const data = await res.json() as { success: boolean; data?: T; error?: ApiError };
+
+    if (!data.success) {
+      throw new FysoApiError(
+        data.error?.code || 'UNKNOWN_ERROR',
+        data.error?.message || 'An unknown error occurred'
+      );
+    }
+
+    return data.data as T;
+  }
+
+  private buildQueryString(params?: ListParams): string {
+    if (!params) return '';
+    const searchParams = new URLSearchParams();
+    for (const [key, value] of Object.entries(params)) {
+      if (value !== undefined && value !== null) {
+        searchParams.append(key, String(value));
+      }
+    }
+    const query = searchParams.toString();
+    return query ? `?${query}` : '';
+  }
+
+  adventures = {
+    list: (params?: ListParams) =>
+      this.request<PaginatedResponse<Adventure>>(
+        'GET',
+        `/api/entities/adventures/records${this.buildQueryString(params)}`
+      ),
+    get: (id: string, resolve?: boolean) =>
+      this.request<Adventure>(
+        'GET',
+        `/api/entities/adventures/records/${id}${resolve ? '?resolve=true' : ''}`
+      ),
+    create: (data: CreateAdventure) =>
+      this.request<Adventure>(
+        'POST',
+        '/api/entities/adventures/records',
+        data
+      ),
+    update: (id: string, data: UpdateAdventure) =>
+      this.request<Adventure>(
+        'PUT',
+        `/api/entities/adventures/records/${id}`,
+        data
+      ),
+    delete: (id: string) =>
+      this.request<void>(
+        'DELETE',
+        `/api/entities/adventures/records/${id}`
+      ),
+  };
+}


### PR DESCRIPTION
## Summary
Closes #10

Configures Fyso tenant and adds TypeScript API client.

## Changes
- `src/api/fyso-client.ts` — typed client for Adventure CRUD via Fyso REST API
- `docs/superpowers/specs/2026-03-28-fyso-tenant-setup.md` — tenant setup documentation
- Fyso Adventure entity with 6 fields configured via MCP
- Business rules for status management and AI generation

## Test Plan
- API client compiles with no errors
- Fyso entity creation/listing works
- AI generation blocked by missing API key (tracked in #17)