### PR TITLE
Add DialoguePanel for text and choices display

### DIFF
--- a/src/engine/DialoguePanel.test.ts
+++ b/src/engine/DialoguePanel.test.ts
@@ -1,0 +1,169 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { DialoguePanel } from './DialoguePanel';
+
+function createMockText() {
+  const handlers: Record<string, (() => void)[]> = {};
+  return {
+    setDepth: vi.fn().mockReturnThis(),
+    setInteractive: vi.fn().mockReturnThis(),
+    setColor: vi.fn().mockReturnThis(),
+    destroy: vi.fn(),
+    on: vi.fn((event: string, handler: () => void) => {
+      if (!handlers[event]) {
+        handlers[event] = [];
+      }
+      handlers[event].push(handler);
+    }),
+    _handlers: handlers,
+    _emit(event: string) {
+      if (handlers[event]) {
+        handlers[event].forEach((h) => h());
+      }
+    },
+  };
+}
+
+function createMockScene() {
+  const textObjects: ReturnType<typeof createMockText>[] = [];
+  return {
+    add: {
+      rectangle: vi.fn(() => ({
+        setDepth: vi.fn().mockReturnThis(),
+      })),
+      text: vi.fn(() => {
+        const t = createMockText();
+        textObjects.push(t);
+        return t;
+      }),
+    },
+    _textObjects: textObjects,
+  };
+}
+
+describe('DialoguePanel', () => {
+  let scene: ReturnType<typeof createMockScene>;
+  let panel: DialoguePanel;
+
+  beforeEach(() => {
+    scene = createMockScene();
+    panel = new DialoguePanel(scene as unknown as Phaser.Scene);
+  });
+
+  it('should create background and border on construction', () => {
+    expect(scene.add.rectangle).toHaveBeenCalledTimes(2);
+  });
+
+  it('should display narrative text via showText', () => {
+    panel.showText('You stand on a sandy beach.');
+
+    expect(scene.add.text).toHaveBeenCalledTimes(1);
+    expect(scene.add.text).toHaveBeenCalledWith(
+      expect.any(Number),
+      expect.any(Number),
+      'You stand on a sandy beach.',
+      expect.objectContaining({
+        fontFamily: 'monospace',
+        color: '#e0e0e0',
+      })
+    );
+  });
+
+  it('should clear previous text when showText is called again', () => {
+    panel.showText('First text.');
+    const firstText = scene._textObjects[0];
+
+    panel.showText('Second text.');
+
+    expect(firstText.destroy).toHaveBeenCalled();
+    expect(scene.add.text).toHaveBeenCalledTimes(2);
+  });
+
+  it('should display choices with prefix', () => {
+    panel.showChoices(['Go north', 'Look around']);
+
+    expect(scene.add.text).toHaveBeenCalledTimes(2);
+    expect(scene.add.text).toHaveBeenCalledWith(
+      expect.any(Number),
+      expect.any(Number),
+      '> Go north',
+      expect.any(Object)
+    );
+    expect(scene.add.text).toHaveBeenCalledWith(
+      expect.any(Number),
+      expect.any(Number),
+      '> Look around',
+      expect.any(Object)
+    );
+  });
+
+  it('should make choices interactive', () => {
+    panel.showChoices(['Option A']);
+
+    const choiceText = scene._textObjects[0];
+    expect(choiceText.setInteractive).toHaveBeenCalledWith({ useHandCursor: true });
+  });
+
+  it('should register and invoke choice callback', () => {
+    const callback = vi.fn();
+    panel.onChoiceSelected(callback);
+    panel.showChoices(['Option A', 'Option B']);
+
+    const secondChoice = scene._textObjects[1];
+    secondChoice._emit('pointerdown');
+
+    expect(callback).toHaveBeenCalledWith(1);
+  });
+
+  it('should not throw if choice clicked without callback', () => {
+    panel.showChoices(['Option A']);
+
+    const choiceText = scene._textObjects[0];
+    expect(() => choiceText._emit('pointerdown')).not.toThrow();
+  });
+
+  it('should highlight choice on hover', () => {
+    panel.showChoices(['Option A']);
+
+    const choiceText = scene._textObjects[0];
+    choiceText._emit('pointerover');
+    expect(choiceText.setColor).toHaveBeenCalledWith('#ffffff');
+
+    choiceText._emit('pointerout');
+    expect(choiceText.setColor).toHaveBeenCalledWith('#e0e0e0');
+  });
+
+  it('should clear all content via clear()', () => {
+    panel.showText('Some text.');
+    panel.showChoices(['A', 'B']);
+
+    const allTexts = [...scene._textObjects];
+    panel.clear();
+
+    for (const t of allTexts) {
+      expect(t.destroy).toHaveBeenCalled();
+    }
+  });
+
+  it('should clear previous choices when showChoices is called again', () => {
+    panel.showChoices(['Old choice']);
+    const oldChoice = scene._textObjects[0];
+
+    panel.showChoices(['New choice']);
+
+    expect(oldChoice.destroy).toHaveBeenCalled();
+  });
+
+  it('should allow replacing callback via onChoiceSelected', () => {
+    const first = vi.fn();
+    const second = vi.fn();
+
+    panel.onChoiceSelected(first);
+    panel.onChoiceSelected(second);
+    panel.showChoices(['Click me']);
+
+    scene._textObjects[0]._emit('pointerdown');
+
+    expect(first).not.toHaveBeenCalled();
+    expect(second).toHaveBeenCalledWith(0);
+  });
+});

--- a/src/engine/DialoguePanel.ts
+++ b/src/engine/DialoguePanel.ts
@@ -1,0 +1,124 @@
+import Phaser from 'phaser';
+
+const PANEL_Y = 450;
+const PANEL_HEIGHT = 150;
+const PANEL_WIDTH = 960;
+const PANEL_BG_COLOR = 0x1a1a2e;
+const PANEL_BORDER_COLOR = 0x3a3a5e;
+const PANEL_BORDER_WIDTH = 2;
+const TEXT_COLOR = '#e0e0e0';
+const TEXT_HIGHLIGHT_COLOR = '#ffffff';
+const TEXT_FONT_SIZE = '16px';
+const TEXT_FONT_FAMILY = 'monospace';
+const TEXT_PADDING_X = 20;
+const TEXT_PADDING_Y = 15;
+const CHOICE_LINE_HEIGHT = 28;
+const CHOICE_PREFIX = '> ';
+
+export class DialoguePanel {
+  private scene: Phaser.Scene;
+  private background: Phaser.GameObjects.Rectangle;
+  private border: Phaser.GameObjects.Rectangle;
+  private narrativeText: Phaser.GameObjects.Text | null = null;
+  private choiceTexts: Phaser.GameObjects.Text[] = [];
+  private choiceCallback: ((index: number) => void) | null = null;
+
+  constructor(scene: Phaser.Scene) {
+    this.scene = scene;
+
+    this.background = scene.add.rectangle(
+      PANEL_WIDTH / 2,
+      PANEL_Y + PANEL_HEIGHT / 2,
+      PANEL_WIDTH,
+      PANEL_HEIGHT,
+      PANEL_BG_COLOR
+    );
+    this.background.setDepth(100);
+
+    this.border = scene.add.rectangle(
+      PANEL_WIDTH / 2,
+      PANEL_Y,
+      PANEL_WIDTH,
+      PANEL_BORDER_WIDTH,
+      PANEL_BORDER_COLOR
+    );
+    this.border.setDepth(101);
+  }
+
+  showText(text: string): void {
+    this.clearContent();
+
+    this.narrativeText = this.scene.add.text(
+      TEXT_PADDING_X,
+      PANEL_Y + TEXT_PADDING_Y,
+      text,
+      {
+        fontFamily: TEXT_FONT_FAMILY,
+        fontSize: TEXT_FONT_SIZE,
+        color: TEXT_COLOR,
+        wordWrap: { width: PANEL_WIDTH - TEXT_PADDING_X * 2 },
+      }
+    );
+    this.narrativeText.setDepth(102);
+  }
+
+  showChoices(choices: string[]): void {
+    this.clearChoices();
+
+    choices.forEach((choice, index) => {
+      const y = PANEL_Y + TEXT_PADDING_Y + index * CHOICE_LINE_HEIGHT;
+      const choiceText = this.scene.add.text(
+        TEXT_PADDING_X,
+        y,
+        `${CHOICE_PREFIX}${choice}`,
+        {
+          fontFamily: TEXT_FONT_FAMILY,
+          fontSize: TEXT_FONT_SIZE,
+          color: TEXT_COLOR,
+          wordWrap: { width: PANEL_WIDTH - TEXT_PADDING_X * 2 },
+        }
+      );
+      choiceText.setDepth(102);
+      choiceText.setInteractive({ useHandCursor: true });
+
+      choiceText.on('pointerover', () => {
+        choiceText.setColor(TEXT_HIGHLIGHT_COLOR);
+      });
+
+      choiceText.on('pointerout', () => {
+        choiceText.setColor(TEXT_COLOR);
+      });
+
+      choiceText.on('pointerdown', () => {
+        if (this.choiceCallback) {
+          this.choiceCallback(index);
+        }
+      });
+
+      this.choiceTexts.push(choiceText);
+    });
+  }
+
+  onChoiceSelected(callback: (index: number) => void): void {
+    this.choiceCallback = callback;
+  }
+
+  clear(): void {
+    this.clearContent();
+  }
+
+  private clearContent(): void {
+    if (this.narrativeText) {
+      this.narrativeText.destroy();
+      this.narrativeText = null;
+    }
+    this.clearChoices();
+  }
+
+  private clearChoices(): void {
+    for (const choiceText of this.choiceTexts) {
+      choiceText.destroy();
+    }
+    this.choiceTexts = [];
+  }
+}


### PR DESCRIPTION
## Summary
Closes #6

LucasArts-style dialogue panel at bottom of canvas with text display and interactive choices.

## Changes
- `src/engine/DialoguePanel.ts` — showText, showChoices, onChoiceSelected, clear
- `src/engine/DialoguePanel.test.ts` — 11 tests

## Test Plan
- `pnpm test` passes