### PR TITLE
Add InventoryBar for item display and selection

### DIFF
--- a/src/engine/InventoryBar.test.ts
+++ b/src/engine/InventoryBar.test.ts
@@ -1,0 +1,242 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { InventoryBar } from './InventoryBar';
+
+function createMockText() {
+  const listeners: Record<string, ((...args: unknown[]) => void)[]> = {};
+  return {
+    x: 0,
+    width: 50,
+    setOrigin: vi.fn().mockReturnThis(),
+    setDepth: vi.fn().mockReturnThis(),
+    setScrollFactor: vi.fn().mockReturnThis(),
+    setInteractive: vi.fn().mockReturnThis(),
+    setColor: vi.fn().mockReturnThis(),
+    setX: vi.fn(function (this: { x: number }, newX: number) {
+      this.x = newX;
+      return this;
+    }),
+    destroy: vi.fn(),
+    on: vi.fn((event: string, cb: (...args: unknown[]) => void) => {
+      if (!listeners[event]) {
+        listeners[event] = [];
+      }
+      listeners[event].push(cb);
+    }),
+    emit: (event: string, ...args: unknown[]) => {
+      if (listeners[event]) {
+        listeners[event].forEach((cb) => cb(...args));
+      }
+    },
+  };
+}
+
+function createMockScene() {
+  const texts: ReturnType<typeof createMockText>[] = [];
+
+  const scene = {
+    add: {
+      rectangle: vi.fn(() => ({
+        setDepth: vi.fn().mockReturnThis(),
+        setScrollFactor: vi.fn().mockReturnThis(),
+      })),
+      text: vi.fn((_x: number, _y: number, _content: string) => {
+        const mockText = createMockText();
+        mockText.x = _x;
+        texts.push(mockText);
+        return mockText;
+      }),
+    },
+    _texts: texts,
+  };
+
+  return scene;
+}
+
+describe('InventoryBar', () => {
+  let scene: ReturnType<typeof createMockScene>;
+  let bar: InventoryBar;
+
+  beforeEach(() => {
+    scene = createMockScene();
+    bar = new InventoryBar(scene as unknown as Phaser.Scene);
+  });
+
+  it('should create a background rectangle', () => {
+    expect(scene.add.rectangle).toHaveBeenCalledWith(480, 20, 960, 40, 0x1a1a2e);
+  });
+
+  it('should start with no items', () => {
+    expect(bar.getItems()).toEqual([]);
+  });
+
+  it('should start with no selection', () => {
+    expect(bar.getSelectedItem()).toBeNull();
+  });
+
+  describe('addItem', () => {
+    it('should add an item', () => {
+      bar.addItem('Key');
+      expect(bar.getItems()).toEqual(['Key']);
+    });
+
+    it('should add multiple items', () => {
+      bar.addItem('Key');
+      bar.addItem('Lamp');
+      bar.addItem('Map');
+      expect(bar.getItems()).toEqual(['Key', 'Lamp', 'Map']);
+    });
+
+    it('should not add duplicate items', () => {
+      bar.addItem('Key');
+      bar.addItem('Key');
+      expect(bar.getItems()).toEqual(['Key']);
+    });
+
+    it('should create a text object for the item', () => {
+      bar.addItem('Key');
+      expect(scene.add.text).toHaveBeenCalledWith(12, 20, 'Key', expect.objectContaining({
+        fontSize: '16px',
+        color: '#ffffff',
+        fontFamily: 'monospace',
+      }));
+    });
+  });
+
+  describe('removeItem', () => {
+    it('should remove an existing item', () => {
+      bar.addItem('Key');
+      bar.addItem('Lamp');
+      bar.removeItem('Key');
+      expect(bar.getItems()).toEqual(['Lamp']);
+    });
+
+    it('should do nothing when removing non-existent item', () => {
+      bar.addItem('Key');
+      bar.removeItem('Sword');
+      expect(bar.getItems()).toEqual(['Key']);
+    });
+
+    it('should destroy the text object on removal', () => {
+      bar.addItem('Key');
+      const textObj = scene._texts[0];
+      bar.removeItem('Key');
+      expect(textObj.destroy).toHaveBeenCalled();
+    });
+
+    it('should clear selection when removing selected item', () => {
+      bar.addItem('Key');
+      // Simulate click to select
+      scene._texts[0].emit('pointerdown');
+      expect(bar.getSelectedItem()).toBe('Key');
+      bar.removeItem('Key');
+      expect(bar.getSelectedItem()).toBeNull();
+    });
+  });
+
+  describe('selection', () => {
+    it('should select an item on click', () => {
+      bar.addItem('Key');
+      scene._texts[0].emit('pointerdown');
+      expect(bar.getSelectedItem()).toBe('Key');
+    });
+
+    it('should highlight selected item with yellow color', () => {
+      bar.addItem('Key');
+      scene._texts[0].emit('pointerdown');
+      expect(scene._texts[0].setColor).toHaveBeenCalledWith('#f1c40f');
+    });
+
+    it('should deselect when clicking the same item again', () => {
+      bar.addItem('Key');
+      scene._texts[0].emit('pointerdown');
+      scene._texts[0].emit('pointerdown');
+      expect(bar.getSelectedItem()).toBeNull();
+    });
+
+    it('should restore color when deselecting', () => {
+      bar.addItem('Key');
+      scene._texts[0].emit('pointerdown'); // select
+      scene._texts[0].emit('pointerdown'); // deselect
+      expect(scene._texts[0].setColor).toHaveBeenCalledWith('#ffffff');
+    });
+
+    it('should switch selection when clicking a different item', () => {
+      bar.addItem('Key');
+      bar.addItem('Lamp');
+      scene._texts[0].emit('pointerdown'); // select Key
+      expect(bar.getSelectedItem()).toBe('Key');
+      scene._texts[1].emit('pointerdown'); // select Lamp
+      expect(bar.getSelectedItem()).toBe('Lamp');
+    });
+
+    it('should deselect previous item when switching selection', () => {
+      bar.addItem('Key');
+      bar.addItem('Lamp');
+      scene._texts[0].emit('pointerdown'); // select Key
+      scene._texts[1].emit('pointerdown'); // select Lamp
+      expect(scene._texts[0].setColor).toHaveBeenCalledWith('#ffffff');
+      expect(scene._texts[1].setColor).toHaveBeenCalledWith('#f1c40f');
+    });
+  });
+
+  describe('clearSelection', () => {
+    it('should clear the current selection', () => {
+      bar.addItem('Key');
+      scene._texts[0].emit('pointerdown');
+      bar.clearSelection();
+      expect(bar.getSelectedItem()).toBeNull();
+    });
+
+    it('should restore item color on clear', () => {
+      bar.addItem('Key');
+      scene._texts[0].emit('pointerdown');
+      bar.clearSelection();
+      expect(scene._texts[0].setColor).toHaveBeenCalledWith('#ffffff');
+    });
+
+    it('should do nothing when no selection', () => {
+      bar.clearSelection();
+      expect(bar.getSelectedItem()).toBeNull();
+    });
+  });
+
+  describe('onItemSelected callback', () => {
+    it('should notify on item selection', () => {
+      const callback = vi.fn();
+      bar.onItemSelected(callback);
+      bar.addItem('Key');
+      scene._texts[0].emit('pointerdown');
+      expect(callback).toHaveBeenCalledWith('Key');
+    });
+
+    it('should notify with null on deselection', () => {
+      const callback = vi.fn();
+      bar.onItemSelected(callback);
+      bar.addItem('Key');
+      scene._texts[0].emit('pointerdown');
+      scene._texts[0].emit('pointerdown');
+      expect(callback).toHaveBeenLastCalledWith(null);
+    });
+
+    it('should notify on clearSelection', () => {
+      const callback = vi.fn();
+      bar.onItemSelected(callback);
+      bar.addItem('Key');
+      scene._texts[0].emit('pointerdown');
+      bar.clearSelection();
+      expect(callback).toHaveBeenLastCalledWith(null);
+    });
+
+    it('should notify when switching items', () => {
+      const callback = vi.fn();
+      bar.onItemSelected(callback);
+      bar.addItem('Key');
+      bar.addItem('Lamp');
+      scene._texts[0].emit('pointerdown');
+      scene._texts[1].emit('pointerdown');
+      expect(callback).toHaveBeenCalledTimes(2);
+      expect(callback).toHaveBeenNthCalledWith(1, 'Key');
+      expect(callback).toHaveBeenNthCalledWith(2, 'Lamp');
+    });
+  });
+});

--- a/src/engine/InventoryBar.ts
+++ b/src/engine/InventoryBar.ts
@@ -1,0 +1,139 @@
+import Phaser from 'phaser';
+
+const BAR_HEIGHT = 40;
+const BAR_WIDTH = 960;
+const BAR_Y = 0;
+const BAR_COLOR = 0x1a1a2e;
+const ITEM_FONT_SIZE = '16px';
+const ITEM_COLOR = '#ffffff';
+const ITEM_SELECTED_COLOR = '#f1c40f';
+const ITEM_PADDING = 16;
+const ITEM_START_X = 12;
+
+interface InventoryEntry {
+  text: Phaser.GameObjects.Text;
+  item: string;
+}
+
+export class InventoryBar {
+  private scene: Phaser.Scene;
+  private background: Phaser.GameObjects.Rectangle;
+  private entries: InventoryEntry[] = [];
+  private selectedItem: string | null = null;
+  private selectionCallback: ((item: string | null) => void) | null = null;
+
+  constructor(scene: Phaser.Scene) {
+    this.scene = scene;
+    this.background = scene.add
+      .rectangle(BAR_WIDTH / 2, BAR_Y + BAR_HEIGHT / 2, BAR_WIDTH, BAR_HEIGHT, BAR_COLOR)
+      .setDepth(100)
+      .setScrollFactor(0);
+  }
+
+  addItem(item: string): void {
+    const existing = this.entries.find((e) => e.item === item);
+    if (existing) {
+      return;
+    }
+
+    const x = this.getNextX();
+    const text = this.scene.add
+      .text(x, BAR_Y + BAR_HEIGHT / 2, item, {
+        fontSize: ITEM_FONT_SIZE,
+        color: ITEM_COLOR,
+        fontFamily: 'monospace',
+      })
+      .setOrigin(0, 0.5)
+      .setDepth(101)
+      .setScrollFactor(0)
+      .setInteractive({ useHandCursor: true });
+
+    text.on('pointerdown', () => {
+      this.handleItemClick(item);
+    });
+
+    this.entries.push({ text, item });
+  }
+
+  removeItem(item: string): void {
+    const index = this.entries.findIndex((e) => e.item === item);
+    if (index === -1) {
+      return;
+    }
+
+    if (this.selectedItem === item) {
+      this.clearSelection();
+    }
+
+    this.entries[index].text.destroy();
+    this.entries.splice(index, 1);
+    this.repositionItems();
+  }
+
+  getSelectedItem(): string | null {
+    return this.selectedItem;
+  }
+
+  clearSelection(): void {
+    if (this.selectedItem !== null) {
+      const entry = this.entries.find((e) => e.item === this.selectedItem);
+      if (entry) {
+        entry.text.setColor(ITEM_COLOR);
+      }
+      this.selectedItem = null;
+      this.notifySelectionChange();
+    }
+  }
+
+  getItems(): string[] {
+    return this.entries.map((e) => e.item);
+  }
+
+  onItemSelected(callback: (item: string | null) => void): void {
+    this.selectionCallback = callback;
+  }
+
+  private handleItemClick(item: string): void {
+    if (this.selectedItem === item) {
+      this.clearSelection();
+    } else {
+      // Deselect previous
+      if (this.selectedItem !== null) {
+        const prev = this.entries.find((e) => e.item === this.selectedItem);
+        if (prev) {
+          prev.text.setColor(ITEM_COLOR);
+        }
+      }
+
+      this.selectedItem = item;
+      const entry = this.entries.find((e) => e.item === item);
+      if (entry) {
+        entry.text.setColor(ITEM_SELECTED_COLOR);
+      }
+      this.notifySelectionChange();
+    }
+  }
+
+  private notifySelectionChange(): void {
+    if (this.selectionCallback) {
+      this.selectionCallback(this.selectedItem);
+    }
+  }
+
+  private getNextX(): number {
+    if (this.entries.length === 0) {
+      return ITEM_START_X;
+    }
+
+    const last = this.entries[this.entries.length - 1];
+    return last.text.x + last.text.width + ITEM_PADDING;
+  }
+
+  private repositionItems(): void {
+    let x = ITEM_START_X;
+    for (const entry of this.entries) {
+      entry.text.setX(x);
+      x += entry.text.width + ITEM_PADDING;
+    }
+  }
+}


### PR DESCRIPTION
## Summary
Closes #7

Inventory bar at top of canvas with item add/remove, click-to-select, and callbacks.

## Changes
- `src/engine/InventoryBar.ts` — addItem, removeItem, getSelectedItem, clearSelection, onItemSelected
- `src/engine/InventoryBar.test.ts` — 23 tests

## Test Plan
- `pnpm test` passes