### PR TITLE
Add MenuScene with prompt input and adventure launcher

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
   },
   "devDependencies": {
     "@types/node": "^25.5.0",
+    "jsdom": "^29.0.1",
     "typescript": "^6.0.2",
     "vite": "^8.0.3",
     "vitest": "^4.1.2"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -18,6 +18,9 @@ importers:
       '@types/node':
         specifier: ^25.5.0
         version: 25.5.0
+      jsdom:
+        specifier: ^29.0.1
+        version: 29.0.1
       typescript:
         specifier: ^6.0.2
         version: 6.0.2
@@ -26,9 +29,60 @@ importers:
         version: 8.0.3(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1)(@types/node@25.5.0)
       vitest:
         specifier: ^4.1.2
-        version: 4.1.2(@types/node@25.5.0)(vite@8.0.3(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1)(@types/node@25.5.0))
+        version: 4.1.2(@types/node@25.5.0)(jsdom@29.0.1)(vite@8.0.3(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1)(@types/node@25.5.0))
 
 packages:
+
+  '@asamuzakjp/css-color@5.0.1':
+    resolution: {integrity: sha512-2SZFvqMyvboVV1d15lMf7XiI3m7SDqXUuKaTymJYLN6dSGadqp+fVojqJlVoMlbZnlTmu3S0TLwLTJpvBMO1Aw==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
+  '@asamuzakjp/dom-selector@7.0.4':
+    resolution: {integrity: sha512-jXR6x4AcT3eIrS2fSNAwJpwirOkGcd+E7F7CP3zjdTqz9B/2huHOL8YJZBgekKwLML+u7qB/6P1LXQuMScsx0w==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
+  '@asamuzakjp/nwsapi@2.3.9':
+    resolution: {integrity: sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==}
+
+  '@bramus/specificity@2.4.2':
+    resolution: {integrity: sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==}
+    hasBin: true
+
+  '@csstools/color-helpers@6.0.2':
+    resolution: {integrity: sha512-LMGQLS9EuADloEFkcTBR3BwV/CGHV7zyDxVRtVDTwdI2Ca4it0CCVTT9wCkxSgokjE5Ho41hEPgb8OEUwoXr6Q==}
+    engines: {node: '>=20.19.0'}
+
+  '@csstools/css-calc@3.1.1':
+    resolution: {integrity: sha512-HJ26Z/vmsZQqs/o3a6bgKslXGFAungXGbinULZO3eMsOyNJHeBBZfup5FiZInOghgoM4Hwnmw+OgbJCNg1wwUQ==}
+    engines: {node: '>=20.19.0'}
+    peerDependencies:
+      '@csstools/css-parser-algorithms': ^4.0.0
+      '@csstools/css-tokenizer': ^4.0.0
+
+  '@csstools/css-color-parser@4.0.2':
+    resolution: {integrity: sha512-0GEfbBLmTFf0dJlpsNU7zwxRIH0/BGEMuXLTCvFYxuL1tNhqzTbtnFICyJLTNK4a+RechKP75e7w42ClXSnJQw==}
+    engines: {node: '>=20.19.0'}
+    peerDependencies:
+      '@csstools/css-parser-algorithms': ^4.0.0
+      '@csstools/css-tokenizer': ^4.0.0
+
+  '@csstools/css-parser-algorithms@4.0.0':
+    resolution: {integrity: sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==}
+    engines: {node: '>=20.19.0'}
+    peerDependencies:
+      '@csstools/css-tokenizer': ^4.0.0
+
+  '@csstools/css-syntax-patches-for-csstree@1.1.2':
+    resolution: {integrity: sha512-5GkLzz4prTIpoyeUiIu3iV6CSG3Plo7xRVOFPKI7FVEJ3mZ0A8SwK0XU3Gl7xAkiQ+mDyam+NNp875/C5y+jSA==}
+    peerDependencies:
+      css-tree: ^3.2.1
+    peerDependenciesMeta:
+      css-tree:
+        optional: true
+
+  '@csstools/css-tokenizer@4.0.0':
+    resolution: {integrity: sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==}
+    engines: {node: '>=20.19.0'}
 
   '@emnapi/core@1.9.1':
     resolution: {integrity: sha512-mukuNALVsoix/w1BJwFzwXBN/dHeejQtuVzcDsfOEsdpCumXb/E9j8w11h5S54tT1xhifGfbbSm/ICrObRb3KA==}
@@ -38,6 +92,15 @@ packages:
 
   '@emnapi/wasi-threads@1.2.0':
     resolution: {integrity: sha512-N10dEJNSsUx41Z6pZsXU8FjPjpBEplgH24sfkmITrBED1/U2Esum9F3lfLrMjKHHjmi557zQn7kR9R+XWXu5Rg==}
+
+  '@exodus/bytes@1.15.0':
+    resolution: {integrity: sha512-UY0nlA+feH81UGSHv92sLEPLCeZFjXOuHhrIo0HQydScuQc8s0A7kL/UdgwgDq8g8ilksmuoF35YVTNphV2aBQ==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+    peerDependencies:
+      '@noble/hashes': ^1.8.0 || ^2.0.0
+    peerDependenciesMeta:
+      '@noble/hashes':
+        optional: true
 
   '@jridgewell/sourcemap-codec@1.5.5':
     resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
@@ -200,6 +263,9 @@ packages:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
     engines: {node: '>=12'}
 
+  bidi-js@1.0.3:
+    resolution: {integrity: sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==}
+
   chai@6.2.2:
     resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
     engines: {node: '>=18'}
@@ -207,9 +273,24 @@ packages:
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
 
+  css-tree@3.2.1:
+    resolution: {integrity: sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==}
+    engines: {node: ^10 || ^12.20.0 || ^14.13.0 || >=15.0.0}
+
+  data-urls@7.0.0:
+    resolution: {integrity: sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
+  decimal.js@10.6.0:
+    resolution: {integrity: sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==}
+
   detect-libc@2.1.2:
     resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
     engines: {node: '>=8'}
+
+  entities@6.0.1:
+    resolution: {integrity: sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==}
+    engines: {node: '>=0.12'}
 
   es-module-lexer@2.0.0:
     resolution: {integrity: sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==}
@@ -238,9 +319,25 @@ packages:
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
     os: [darwin]
 
+  html-encoding-sniffer@6.0.0:
+    resolution: {integrity: sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
   inkjs@2.4.0:
     resolution: {integrity: sha512-EoPCYESIbMtfI8SqEDZCJwn+A5is0QozMLw250iic1ReJCgZpRKIezWj0VqgRUzAx0f3MmEbsUjY/ILe2815JQ==}
     hasBin: true
+
+  is-potential-custom-element-name@1.0.1:
+    resolution: {integrity: sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==}
+
+  jsdom@29.0.1:
+    resolution: {integrity: sha512-z6JOK5gRO7aMybVq/y/MlIpKh8JIi68FBKMUtKkK2KH/wMSRlCxQ682d08LB9fYXplyY/UXG8P4XXTScmdjApg==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24.0.0}
+    peerDependencies:
+      canvas: ^3.0.0
+    peerDependenciesMeta:
+      canvas:
+        optional: true
 
   lightningcss-android-arm64@1.32.0:
     resolution: {integrity: sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==}
@@ -316,8 +413,15 @@ packages:
     resolution: {integrity: sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==}
     engines: {node: '>= 12.0.0'}
 
+  lru-cache@11.2.7:
+    resolution: {integrity: sha512-aY/R+aEsRelme17KGQa/1ZSIpLpNYYrhcrepKTZgE+W3WM16YMCaPwOHLHsmopZHELU0Ojin1lPVxKR0MihncA==}
+    engines: {node: 20 || >=22}
+
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
+
+  mdn-data@2.27.1:
+    resolution: {integrity: sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==}
 
   nanoid@3.3.11:
     resolution: {integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==}
@@ -326,6 +430,9 @@ packages:
 
   obug@2.1.1:
     resolution: {integrity: sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==}
+
+  parse5@8.0.0:
+    resolution: {integrity: sha512-9m4m5GSgXjL4AjumKzq1Fgfp3Z8rsvjRNbnkVwfu2ImRqE5D0LnY2QfDen18FSY9C573YU5XxSapdHZTZ2WolA==}
 
   pathe@2.0.3:
     resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
@@ -344,10 +451,22 @@ packages:
     resolution: {integrity: sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==}
     engines: {node: ^10 || ^12 || >=14}
 
+  punycode@2.3.1:
+    resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
+    engines: {node: '>=6'}
+
+  require-from-string@2.0.2:
+    resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
+    engines: {node: '>=0.10.0'}
+
   rolldown@1.0.0-rc.12:
     resolution: {integrity: sha512-yP4USLIMYrwpPHEFB5JGH1uxhcslv6/hL0OyvTuY+3qlOSJvZ7ntYnoWpehBxufkgN0cvXxppuTu5hHa/zPh+A==}
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
+
+  saxes@6.0.0:
+    resolution: {integrity: sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==}
+    engines: {node: '>=v12.22.7'}
 
   siginfo@2.0.0:
     resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
@@ -361,6 +480,9 @@ packages:
 
   std-env@4.0.0:
     resolution: {integrity: sha512-zUMPtQ/HBY3/50VbpkupYHbRroTRZJPRLvreamgErJVys0ceuzMkD44J/QjqhHjOzK42GQ3QZIeFG1OYfOtKqQ==}
+
+  symbol-tree@3.2.4:
+    resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
 
   tinybench@2.9.0:
     resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
@@ -377,6 +499,21 @@ packages:
     resolution: {integrity: sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==}
     engines: {node: '>=14.0.0'}
 
+  tldts-core@7.0.27:
+    resolution: {integrity: sha512-YQ7uPjgWUibIK6DW5lrKujGwUKhLevU4hcGbP5O6TcIUb+oTjJYJVWPS4nZsIHrEEEG6myk/oqAJUEQmpZrHsg==}
+
+  tldts@7.0.27:
+    resolution: {integrity: sha512-I4FZcVFcqCRuT0ph6dCDpPuO4Xgzvh+spkcTr1gK7peIvxWauoloVO0vuy1FQnijT63ss6AsHB6+OIM4aXHbPg==}
+    hasBin: true
+
+  tough-cookie@6.0.1:
+    resolution: {integrity: sha512-LktZQb3IeoUWB9lqR5EWTHgW/VTITCXg4D21M+lvybRVdylLrRMnqaIONLVb5mav8vM19m44HIcGq4qASeu2Qw==}
+    engines: {node: '>=16'}
+
+  tr46@6.0.0:
+    resolution: {integrity: sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==}
+    engines: {node: '>=20'}
+
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
 
@@ -387,6 +524,10 @@ packages:
 
   undici-types@7.18.2:
     resolution: {integrity: sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==}
+
+  undici@7.24.6:
+    resolution: {integrity: sha512-Xi4agocCbRzt0yYMZGMA6ApD7gvtUFaxm4ZmeacWI4cZxaF6C+8I8QfofC20NAePiB/IcvZmzkJ7XPa471AEtA==}
+    engines: {node: '>=20.18.1'}
 
   vite@8.0.3:
     resolution: {integrity: sha512-B9ifbFudT1TFhfltfaIPgjo9Z3mDynBTJSUYxTjOQruf/zHH+ezCQKcoqO+h7a9Pw9Nm/OtlXAiGT1axBgwqrQ==}
@@ -466,12 +607,81 @@ packages:
       jsdom:
         optional: true
 
+  w3c-xmlserializer@5.0.0:
+    resolution: {integrity: sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==}
+    engines: {node: '>=18'}
+
+  webidl-conversions@8.0.1:
+    resolution: {integrity: sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==}
+    engines: {node: '>=20'}
+
+  whatwg-mimetype@5.0.0:
+    resolution: {integrity: sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==}
+    engines: {node: '>=20'}
+
+  whatwg-url@16.0.1:
+    resolution: {integrity: sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
   why-is-node-running@2.3.0:
     resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
     engines: {node: '>=8'}
     hasBin: true
 
+  xml-name-validator@5.0.0:
+    resolution: {integrity: sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==}
+    engines: {node: '>=18'}
+
+  xmlchars@2.2.0:
+    resolution: {integrity: sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==}
+
 snapshots:
+
+  '@asamuzakjp/css-color@5.0.1':
+    dependencies:
+      '@csstools/css-calc': 3.1.1(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-color-parser': 4.0.2(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-tokenizer': 4.0.0
+      lru-cache: 11.2.7
+
+  '@asamuzakjp/dom-selector@7.0.4':
+    dependencies:
+      '@asamuzakjp/nwsapi': 2.3.9
+      bidi-js: 1.0.3
+      css-tree: 3.2.1
+      is-potential-custom-element-name: 1.0.1
+      lru-cache: 11.2.7
+
+  '@asamuzakjp/nwsapi@2.3.9': {}
+
+  '@bramus/specificity@2.4.2':
+    dependencies:
+      css-tree: 3.2.1
+
+  '@csstools/color-helpers@6.0.2': {}
+
+  '@csstools/css-calc@3.1.1(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)':
+    dependencies:
+      '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-tokenizer': 4.0.0
+
+  '@csstools/css-color-parser@4.0.2(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)':
+    dependencies:
+      '@csstools/color-helpers': 6.0.2
+      '@csstools/css-calc': 3.1.1(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-tokenizer': 4.0.0
+
+  '@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0)':
+    dependencies:
+      '@csstools/css-tokenizer': 4.0.0
+
+  '@csstools/css-syntax-patches-for-csstree@1.1.2(css-tree@3.2.1)':
+    optionalDependencies:
+      css-tree: 3.2.1
+
+  '@csstools/css-tokenizer@4.0.0': {}
 
   '@emnapi/core@1.9.1':
     dependencies:
@@ -488,6 +698,8 @@ snapshots:
     dependencies:
       tslib: 2.8.1
     optional: true
+
+  '@exodus/bytes@1.15.0': {}
 
   '@jridgewell/sourcemap-codec@1.5.5': {}
 
@@ -615,11 +827,31 @@ snapshots:
 
   assertion-error@2.0.1: {}
 
+  bidi-js@1.0.3:
+    dependencies:
+      require-from-string: 2.0.2
+
   chai@6.2.2: {}
 
   convert-source-map@2.0.0: {}
 
+  css-tree@3.2.1:
+    dependencies:
+      mdn-data: 2.27.1
+      source-map-js: 1.2.1
+
+  data-urls@7.0.0:
+    dependencies:
+      whatwg-mimetype: 5.0.0
+      whatwg-url: 16.0.1
+    transitivePeerDependencies:
+      - '@noble/hashes'
+
+  decimal.js@10.6.0: {}
+
   detect-libc@2.1.2: {}
+
+  entities@6.0.1: {}
 
   es-module-lexer@2.0.0: {}
 
@@ -638,7 +870,41 @@ snapshots:
   fsevents@2.3.3:
     optional: true
 
+  html-encoding-sniffer@6.0.0:
+    dependencies:
+      '@exodus/bytes': 1.15.0
+    transitivePeerDependencies:
+      - '@noble/hashes'
+
   inkjs@2.4.0: {}
+
+  is-potential-custom-element-name@1.0.1: {}
+
+  jsdom@29.0.1:
+    dependencies:
+      '@asamuzakjp/css-color': 5.0.1
+      '@asamuzakjp/dom-selector': 7.0.4
+      '@bramus/specificity': 2.4.2
+      '@csstools/css-syntax-patches-for-csstree': 1.1.2(css-tree@3.2.1)
+      '@exodus/bytes': 1.15.0
+      css-tree: 3.2.1
+      data-urls: 7.0.0
+      decimal.js: 10.6.0
+      html-encoding-sniffer: 6.0.0
+      is-potential-custom-element-name: 1.0.1
+      lru-cache: 11.2.7
+      parse5: 8.0.0
+      saxes: 6.0.0
+      symbol-tree: 3.2.4
+      tough-cookie: 6.0.1
+      undici: 7.24.6
+      w3c-xmlserializer: 5.0.0
+      webidl-conversions: 8.0.1
+      whatwg-mimetype: 5.0.0
+      whatwg-url: 16.0.1
+      xml-name-validator: 5.0.0
+    transitivePeerDependencies:
+      - '@noble/hashes'
 
   lightningcss-android-arm64@1.32.0:
     optional: true
@@ -689,13 +955,21 @@ snapshots:
       lightningcss-win32-arm64-msvc: 1.32.0
       lightningcss-win32-x64-msvc: 1.32.0
 
+  lru-cache@11.2.7: {}
+
   magic-string@0.30.21:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
 
+  mdn-data@2.27.1: {}
+
   nanoid@3.3.11: {}
 
   obug@2.1.1: {}
+
+  parse5@8.0.0:
+    dependencies:
+      entities: 6.0.1
 
   pathe@2.0.3: {}
 
@@ -712,6 +986,10 @@ snapshots:
       nanoid: 3.3.11
       picocolors: 1.1.1
       source-map-js: 1.2.1
+
+  punycode@2.3.1: {}
+
+  require-from-string@2.0.2: {}
 
   rolldown@1.0.0-rc.12(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1):
     dependencies:
@@ -737,6 +1015,10 @@ snapshots:
       - '@emnapi/core'
       - '@emnapi/runtime'
 
+  saxes@6.0.0:
+    dependencies:
+      xmlchars: 2.2.0
+
   siginfo@2.0.0: {}
 
   source-map-js@1.2.1: {}
@@ -744,6 +1026,8 @@ snapshots:
   stackback@0.0.2: {}
 
   std-env@4.0.0: {}
+
+  symbol-tree@3.2.4: {}
 
   tinybench@2.9.0: {}
 
@@ -756,12 +1040,28 @@ snapshots:
 
   tinyrainbow@3.1.0: {}
 
+  tldts-core@7.0.27: {}
+
+  tldts@7.0.27:
+    dependencies:
+      tldts-core: 7.0.27
+
+  tough-cookie@6.0.1:
+    dependencies:
+      tldts: 7.0.27
+
+  tr46@6.0.0:
+    dependencies:
+      punycode: 2.3.1
+
   tslib@2.8.1:
     optional: true
 
   typescript@6.0.2: {}
 
   undici-types@7.18.2: {}
+
+  undici@7.24.6: {}
 
   vite@8.0.3(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1)(@types/node@25.5.0):
     dependencies:
@@ -777,7 +1077,7 @@ snapshots:
       - '@emnapi/core'
       - '@emnapi/runtime'
 
-  vitest@4.1.2(@types/node@25.5.0)(vite@8.0.3(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1)(@types/node@25.5.0)):
+  vitest@4.1.2(@types/node@25.5.0)(jsdom@29.0.1)(vite@8.0.3(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1)(@types/node@25.5.0)):
     dependencies:
       '@vitest/expect': 4.1.2
       '@vitest/mocker': 4.1.2(vite@8.0.3(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1)(@types/node@25.5.0))
@@ -801,10 +1101,31 @@ snapshots:
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 25.5.0
+      jsdom: 29.0.1
     transitivePeerDependencies:
       - msw
+
+  w3c-xmlserializer@5.0.0:
+    dependencies:
+      xml-name-validator: 5.0.0
+
+  webidl-conversions@8.0.1: {}
+
+  whatwg-mimetype@5.0.0: {}
+
+  whatwg-url@16.0.1:
+    dependencies:
+      '@exodus/bytes': 1.15.0
+      tr46: 6.0.0
+      webidl-conversions: 8.0.1
+    transitivePeerDependencies:
+      - '@noble/hashes'
 
   why-is-node-running@2.3.0:
     dependencies:
       siginfo: 2.0.0
       stackback: 0.0.2
+
+  xml-name-validator@5.0.0: {}
+
+  xmlchars@2.2.0: {}

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,4 +1,5 @@
 import Phaser from 'phaser';
+import { MenuScene } from './scenes/MenuScene';
 import { BootScene } from './scenes/BootScene';
 
 export const gameConfig: Phaser.Types.Core.GameConfig = {
@@ -7,5 +8,5 @@ export const gameConfig: Phaser.Types.Core.GameConfig = {
   height: 600,
   parent: 'game-container',
   backgroundColor: '#1a1a2e',
-  scene: [BootScene],
+  scene: [MenuScene, BootScene],
 };

--- a/src/scenes/MenuScene.test.ts
+++ b/src/scenes/MenuScene.test.ts
@@ -1,0 +1,394 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+// Mock the Fyso API module before importing MenuScene
+vi.mock("../api/fyso", () => ({
+  createAdventure: vi.fn(),
+  listAdventures: vi.fn(),
+}));
+
+// Mock Phaser
+vi.mock("phaser", () => ({
+  default: {
+    Scene: class MockScene {
+      constructor() {
+        // noop
+      }
+    },
+  },
+}));
+
+import { createAdventure, listAdventures } from "../api/fyso";
+import type { Adventure } from "../types/adventure";
+import { MenuScene } from "./MenuScene";
+
+const mockedCreateAdventure = vi.mocked(createAdventure);
+const mockedListAdventures = vi.mocked(listAdventures);
+
+function createMockAdventure(overrides?: Partial<Adventure>): Adventure {
+  return {
+    id: "adv-1",
+    title: "Pirate Adventure",
+    prompt: "A pirate adventure on a tropical island",
+    scenes_count: 3,
+    ink_script: "-> start",
+    scene_metadata: { scenes: {} },
+    status: "ready",
+    created_at: "2026-03-28T00:00:00Z",
+    ...overrides,
+  };
+}
+
+function createMenuScene(): MenuScene {
+  const scene = new MenuScene();
+
+  // Mock Phaser.Scene properties used by MenuScene
+  const mockGame = {
+    canvas: Object.assign(document.createElement("canvas"), {
+      width: 960,
+      height: 600,
+    }),
+  };
+  const gameContainer = document.createElement("div");
+  gameContainer.id = "game-container";
+  gameContainer.appendChild(mockGame.canvas);
+  document.body.appendChild(gameContainer);
+
+  Object.defineProperty(scene, "game", { value: mockGame, writable: true });
+  Object.defineProperty(scene, "scene", {
+    value: {
+      start: vi.fn(),
+    },
+    writable: true,
+  });
+
+  return scene;
+}
+
+describe("MenuScene", () => {
+  let scene: MenuScene;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockedListAdventures.mockResolvedValue([]);
+    scene = createMenuScene();
+  });
+
+  afterEach(() => {
+    scene.shutdown();
+    const container = document.getElementById("game-container");
+    if (container) container.remove();
+  });
+
+  describe("DOM element creation", () => {
+    it("creates the menu container on create()", () => {
+      scene.create();
+      const el = document.getElementById("menu-scene");
+      expect(el).not.toBeNull();
+    });
+
+    it("creates a prompt input with correct placeholder", () => {
+      scene.create();
+      const input = document.getElementById("menu-prompt-input") as HTMLInputElement;
+      expect(input).not.toBeNull();
+      expect(input.placeholder).toBe("Describe your adventure...");
+    });
+
+    it("creates a Generate button", () => {
+      scene.create();
+      const btn = document.getElementById("menu-generate-btn") as HTMLButtonElement;
+      expect(btn).not.toBeNull();
+      expect(btn.textContent).toBe("Generate");
+    });
+
+    it("creates a Play Example button", () => {
+      scene.create();
+      const btn = document.getElementById("menu-example-btn") as HTMLButtonElement;
+      expect(btn).not.toBeNull();
+      expect(btn.textContent).toBe("Play Example");
+    });
+
+    it("creates a status text element", () => {
+      scene.create();
+      const status = document.getElementById("menu-status") as HTMLParagraphElement;
+      expect(status).not.toBeNull();
+      expect(status.textContent).toBe("");
+    });
+
+    it("creates the adventure list section", () => {
+      scene.create();
+      const list = document.getElementById("menu-adventure-list");
+      expect(list).not.toBeNull();
+    });
+  });
+
+  describe("DOM cleanup", () => {
+    it("removes DOM elements on shutdown()", () => {
+      scene.create();
+      expect(document.getElementById("menu-scene")).not.toBeNull();
+
+      scene.shutdown();
+      expect(document.getElementById("menu-scene")).toBeNull();
+    });
+
+    it("handles shutdown when no DOM exists", () => {
+      expect(() => scene.shutdown()).not.toThrow();
+    });
+
+    it("removes DOM when navigating to BootScene", () => {
+      scene.create();
+      const exampleBtn = document.getElementById("menu-example-btn") as HTMLButtonElement;
+      exampleBtn.click();
+
+      expect(document.getElementById("menu-scene")).toBeNull();
+    });
+  });
+
+  describe("Play Example button", () => {
+    it("navigates to BootScene without adventure ID", () => {
+      scene.create();
+      const exampleBtn = document.getElementById("menu-example-btn") as HTMLButtonElement;
+      exampleBtn.click();
+
+      const sceneManager = (scene as unknown as { scene: { start: ReturnType<typeof vi.fn> } }).scene;
+      expect(sceneManager.start).toHaveBeenCalledWith("BootScene", { adventureId: undefined });
+    });
+  });
+
+  describe("Generate adventure", () => {
+    it("does nothing when prompt is empty", async () => {
+      scene.create();
+      const generateBtn = document.getElementById("menu-generate-btn") as HTMLButtonElement;
+      generateBtn.click();
+
+      expect(mockedCreateAdventure).not.toHaveBeenCalled();
+    });
+
+    it("calls createAdventure with prompt text", async () => {
+      const adventure = createMockAdventure();
+      mockedCreateAdventure.mockResolvedValue(adventure);
+
+      scene.create();
+      const input = document.getElementById("menu-prompt-input") as HTMLInputElement;
+      input.value = "A mystery in a haunted mansion";
+
+      const generateBtn = document.getElementById("menu-generate-btn") as HTMLButtonElement;
+      generateBtn.click();
+
+      expect(mockedCreateAdventure).toHaveBeenCalledWith("A mystery in a haunted mansion", 3);
+    });
+
+    it("shows loading state while generating", () => {
+      mockedCreateAdventure.mockReturnValue(new Promise(() => {
+        // Never resolves — keeps loading state
+      }));
+
+      scene.create();
+      const input = document.getElementById("menu-prompt-input") as HTMLInputElement;
+      input.value = "Test adventure";
+
+      const generateBtn = document.getElementById("menu-generate-btn") as HTMLButtonElement;
+      generateBtn.click();
+
+      const status = document.getElementById("menu-status") as HTMLParagraphElement;
+      expect(status.textContent).toBe("Generating adventure...");
+      expect(generateBtn.disabled).toBe(true);
+      expect(input.disabled).toBe(true);
+    });
+
+    it("navigates to BootScene with adventure ID on success", async () => {
+      const adventure = createMockAdventure({ id: "adv-42" });
+      mockedCreateAdventure.mockResolvedValue(adventure);
+
+      scene.create();
+      const input = document.getElementById("menu-prompt-input") as HTMLInputElement;
+      input.value = "Pirate adventure";
+
+      const generateBtn = document.getElementById("menu-generate-btn") as HTMLButtonElement;
+      generateBtn.click();
+
+      // Wait for the async handler to resolve
+      await vi.waitFor(() => {
+        const sceneManager = (scene as unknown as { scene: { start: ReturnType<typeof vi.fn> } }).scene;
+        expect(sceneManager.start).toHaveBeenCalledWith("BootScene", { adventureId: "adv-42" });
+      });
+    });
+
+    it("shows error state on failure", async () => {
+      mockedCreateAdventure.mockRejectedValue(new Error("Network error"));
+
+      scene.create();
+      const input = document.getElementById("menu-prompt-input") as HTMLInputElement;
+      input.value = "Test adventure";
+
+      const generateBtn = document.getElementById("menu-generate-btn") as HTMLButtonElement;
+      generateBtn.click();
+
+      await vi.waitFor(() => {
+        const status = document.getElementById("menu-status") as HTMLParagraphElement;
+        expect(status.textContent).toBe("Network error");
+      });
+
+      const retryBtn = document.getElementById("menu-retry-btn") as HTMLButtonElement;
+      expect(retryBtn.style.display).not.toBe("none");
+    });
+
+    it("handles Enter key to generate", () => {
+      mockedCreateAdventure.mockReturnValue(new Promise(() => {
+        // Never resolves
+      }));
+
+      scene.create();
+      const input = document.getElementById("menu-prompt-input") as HTMLInputElement;
+      input.value = "Enter key test";
+
+      input.dispatchEvent(new KeyboardEvent("keydown", { key: "Enter" }));
+
+      expect(mockedCreateAdventure).toHaveBeenCalledWith("Enter key test", 3);
+    });
+
+    it("prevents duplicate requests while loading", () => {
+      mockedCreateAdventure.mockReturnValue(new Promise(() => {
+        // Never resolves
+      }));
+
+      scene.create();
+      const input = document.getElementById("menu-prompt-input") as HTMLInputElement;
+      input.value = "Test adventure";
+
+      const generateBtn = document.getElementById("menu-generate-btn") as HTMLButtonElement;
+      generateBtn.click();
+      generateBtn.click();
+      generateBtn.click();
+
+      expect(mockedCreateAdventure).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("Retry", () => {
+    it("retry button triggers another generation attempt", async () => {
+      mockedCreateAdventure.mockRejectedValueOnce(new Error("First fail"));
+
+      scene.create();
+      const input = document.getElementById("menu-prompt-input") as HTMLInputElement;
+      input.value = "Retry test";
+
+      const generateBtn = document.getElementById("menu-generate-btn") as HTMLButtonElement;
+      generateBtn.click();
+
+      // Wait for error state
+      await vi.waitFor(() => {
+        const status = document.getElementById("menu-status") as HTMLParagraphElement;
+        expect(status.textContent).toBe("First fail");
+      });
+
+      // Now retry
+      const adventure = createMockAdventure();
+      mockedCreateAdventure.mockResolvedValueOnce(adventure);
+
+      const retryBtn = document.getElementById("menu-retry-btn") as HTMLButtonElement;
+      retryBtn.click();
+
+      expect(mockedCreateAdventure).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe("Adventure list", () => {
+    it("fetches adventures on create()", () => {
+      scene.create();
+      expect(mockedListAdventures).toHaveBeenCalled();
+    });
+
+    it("renders adventure items", async () => {
+      const adventures = [
+        createMockAdventure({ id: "adv-1", title: "First Adventure" }),
+        createMockAdventure({ id: "adv-2", title: "Second Adventure", status: "generating" }),
+      ];
+      mockedListAdventures.mockResolvedValue(adventures);
+
+      scene.create();
+
+      await vi.waitFor(() => {
+        const items = document.querySelectorAll(".menu-adventure-item");
+        expect(items.length).toBe(2);
+      });
+    });
+
+    it("navigates to BootScene when clicking a ready adventure", async () => {
+      const adventures = [
+        createMockAdventure({ id: "adv-1", title: "Ready Adventure", status: "ready" }),
+      ];
+      mockedListAdventures.mockResolvedValue(adventures);
+
+      scene.create();
+
+      await vi.waitFor(() => {
+        const items = document.querySelectorAll(".menu-adventure-item");
+        expect(items.length).toBe(1);
+      });
+
+      const item = document.querySelector(".menu-adventure-item") as HTMLDivElement;
+      item.click();
+
+      const sceneManager = (scene as unknown as { scene: { start: ReturnType<typeof vi.fn> } }).scene;
+      expect(sceneManager.start).toHaveBeenCalledWith("BootScene", { adventureId: "adv-1" });
+    });
+
+    it("does not navigate when clicking a generating adventure", async () => {
+      const adventures = [
+        createMockAdventure({ id: "adv-1", status: "generating" }),
+      ];
+      mockedListAdventures.mockResolvedValue(adventures);
+
+      scene.create();
+
+      await vi.waitFor(() => {
+        const items = document.querySelectorAll(".menu-adventure-item");
+        expect(items.length).toBe(1);
+      });
+
+      const item = document.querySelector(".menu-adventure-item") as HTMLDivElement;
+      item.click();
+
+      const sceneManager = (scene as unknown as { scene: { start: ReturnType<typeof vi.fn> } }).scene;
+      expect(sceneManager.start).not.toHaveBeenCalled();
+    });
+
+    it("shows empty state when no adventures exist", async () => {
+      mockedListAdventures.mockResolvedValue([]);
+
+      scene.create();
+
+      await vi.waitFor(() => {
+        const container = document.getElementById("menu-adventures-container");
+        expect(container?.textContent).toContain("No adventures yet");
+      });
+    });
+
+    it("handles list fetch error silently", async () => {
+      mockedListAdventures.mockRejectedValue(new Error("Fetch failed"));
+
+      scene.create();
+
+      // Should not throw and scene should still be functional
+      await vi.waitFor(() => {
+        expect(document.getElementById("menu-scene")).not.toBeNull();
+      });
+    });
+  });
+
+  describe("Config integration", () => {
+    it("MenuScene is registered in game config", async () => {
+      const fs = await import("node:fs");
+      const path = await import("node:path");
+
+      const configSource = fs.readFileSync(
+        path.join(import.meta.dirname, "..", "config.ts"),
+        "utf-8"
+      );
+
+      expect(configSource).toContain("MenuScene");
+      expect(configSource).toContain("scene: [MenuScene, BootScene]");
+    });
+  });
+});

--- a/src/scenes/MenuScene.ts
+++ b/src/scenes/MenuScene.ts
@@ -1,0 +1,345 @@
+import Phaser from "phaser";
+import { createAdventure, listAdventures } from "../api/fyso";
+import type { Adventure } from "../types/adventure";
+
+type MenuState = "idle" | "loading" | "error";
+
+export class MenuScene extends Phaser.Scene {
+  private container: HTMLDivElement | null = null;
+  private state: MenuState = "idle";
+  private adventures: Adventure[] = [];
+  private errorMessage = "";
+
+  constructor() {
+    super({ key: "MenuScene" });
+  }
+
+  create(): void {
+    this.state = "idle";
+    this.adventures = [];
+    this.errorMessage = "";
+    this.buildDOM();
+    this.fetchAdventures();
+  }
+
+  shutdown(): void {
+    this.removeDOM();
+  }
+
+  private buildDOM(): void {
+    this.removeDOM();
+
+    const canvas = this.game.canvas;
+    const parent = canvas.parentElement ?? document.body;
+
+    const container = document.createElement("div");
+    container.id = "menu-scene";
+    container.style.cssText = `
+      position: absolute;
+      top: 0;
+      left: 0;
+      width: ${canvas.width}px;
+      height: ${canvas.height}px;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      justify-content: flex-start;
+      padding: 40px 20px;
+      box-sizing: border-box;
+      font-family: monospace;
+      color: #e0e0e0;
+      background: rgba(26, 26, 46, 0.95);
+      overflow-y: auto;
+    `;
+
+    // Title
+    const title = document.createElement("h1");
+    title.textContent = "VerbEngine";
+    title.style.cssText = `
+      font-size: 36px;
+      margin: 0 0 8px 0;
+      color: #ffffff;
+      letter-spacing: 2px;
+    `;
+    container.appendChild(title);
+
+    const subtitle = document.createElement("p");
+    subtitle.textContent = "AI-powered point-and-click adventures";
+    subtitle.style.cssText = `
+      font-size: 14px;
+      margin: 0 0 32px 0;
+      color: #888;
+    `;
+    container.appendChild(subtitle);
+
+    // Prompt input section
+    const promptSection = document.createElement("div");
+    promptSection.style.cssText = `
+      width: 100%;
+      max-width: 560px;
+      margin-bottom: 24px;
+    `;
+
+    const promptInput = document.createElement("input");
+    promptInput.id = "menu-prompt-input";
+    promptInput.type = "text";
+    promptInput.placeholder = "Describe your adventure...";
+    promptInput.style.cssText = `
+      width: 100%;
+      padding: 12px 16px;
+      font-size: 16px;
+      font-family: monospace;
+      background: #2a2a3e;
+      border: 1px solid #444;
+      border-radius: 6px;
+      color: #e0e0e0;
+      outline: none;
+      box-sizing: border-box;
+      margin-bottom: 12px;
+    `;
+    promptSection.appendChild(promptInput);
+
+    const buttonRow = document.createElement("div");
+    buttonRow.style.cssText = `
+      display: flex;
+      gap: 12px;
+    `;
+
+    const generateBtn = document.createElement("button");
+    generateBtn.id = "menu-generate-btn";
+    generateBtn.textContent = "Generate";
+    generateBtn.style.cssText = this.buttonStyle("#4a9eff");
+    buttonRow.appendChild(generateBtn);
+
+    const exampleBtn = document.createElement("button");
+    exampleBtn.id = "menu-example-btn";
+    exampleBtn.textContent = "Play Example";
+    exampleBtn.style.cssText = this.buttonStyle("#666");
+    buttonRow.appendChild(exampleBtn);
+
+    promptSection.appendChild(buttonRow);
+
+    // Status text (loading / error)
+    const statusText = document.createElement("p");
+    statusText.id = "menu-status";
+    statusText.style.cssText = `
+      font-size: 14px;
+      margin: 12px 0 0 0;
+      min-height: 20px;
+      color: #888;
+    `;
+    promptSection.appendChild(statusText);
+
+    // Retry button (hidden by default)
+    const retryBtn = document.createElement("button");
+    retryBtn.id = "menu-retry-btn";
+    retryBtn.textContent = "Retry";
+    retryBtn.style.cssText = this.buttonStyle("#cc4444");
+    retryBtn.style.display = "none";
+    retryBtn.style.marginTop = "8px";
+    promptSection.appendChild(retryBtn);
+
+    container.appendChild(promptSection);
+
+    // Adventure list section
+    const listSection = document.createElement("div");
+    listSection.id = "menu-adventure-list";
+    listSection.style.cssText = `
+      width: 100%;
+      max-width: 560px;
+    `;
+
+    const listTitle = document.createElement("h2");
+    listTitle.textContent = "Your Adventures";
+    listTitle.style.cssText = `
+      font-size: 18px;
+      margin: 0 0 12px 0;
+      color: #ccc;
+    `;
+    listSection.appendChild(listTitle);
+
+    const listContainer = document.createElement("div");
+    listContainer.id = "menu-adventures-container";
+    listSection.appendChild(listContainer);
+
+    container.appendChild(listSection);
+
+    parent.style.position = "relative";
+    parent.appendChild(container);
+    this.container = container;
+
+    // Event listeners
+    generateBtn.addEventListener("click", () => this.handleGenerate(promptInput.value));
+    promptInput.addEventListener("keydown", (e: KeyboardEvent) => {
+      if (e.key === "Enter") {
+        this.handleGenerate(promptInput.value);
+      }
+    });
+    exampleBtn.addEventListener("click", () => this.navigateToBootScene());
+    retryBtn.addEventListener("click", () => this.handleGenerate(promptInput.value));
+  }
+
+  private buttonStyle(bgColor: string): string {
+    return `
+      padding: 10px 24px;
+      font-size: 14px;
+      font-family: monospace;
+      background: ${bgColor};
+      border: none;
+      border-radius: 6px;
+      color: #ffffff;
+      cursor: pointer;
+      transition: opacity 0.2s;
+    `;
+  }
+
+  private updateStatus(): void {
+    if (!this.container) return;
+
+    const statusEl = this.container.querySelector<HTMLParagraphElement>("#menu-status");
+    const generateBtn = this.container.querySelector<HTMLButtonElement>("#menu-generate-btn");
+    const promptInput = this.container.querySelector<HTMLInputElement>("#menu-prompt-input");
+    const retryBtn = this.container.querySelector<HTMLButtonElement>("#menu-retry-btn");
+
+    if (!statusEl || !generateBtn || !promptInput || !retryBtn) return;
+
+    switch (this.state) {
+      case "idle":
+        statusEl.textContent = "";
+        statusEl.style.color = "#888";
+        generateBtn.disabled = false;
+        generateBtn.style.opacity = "1";
+        promptInput.disabled = false;
+        retryBtn.style.display = "none";
+        break;
+      case "loading":
+        statusEl.textContent = "Generating adventure...";
+        statusEl.style.color = "#4a9eff";
+        generateBtn.disabled = true;
+        generateBtn.style.opacity = "0.5";
+        promptInput.disabled = true;
+        retryBtn.style.display = "none";
+        break;
+      case "error":
+        statusEl.textContent = this.errorMessage;
+        statusEl.style.color = "#cc4444";
+        generateBtn.disabled = false;
+        generateBtn.style.opacity = "1";
+        promptInput.disabled = false;
+        retryBtn.style.display = "inline-block";
+        break;
+    }
+  }
+
+  private async handleGenerate(prompt: string): Promise<void> {
+    const trimmed = prompt.trim();
+    if (!trimmed) return;
+    if (this.state === "loading") return;
+
+    this.state = "loading";
+    this.updateStatus();
+
+    try {
+      const adventure = await createAdventure(trimmed, 3);
+      this.navigateToBootScene(adventure.id);
+    } catch (err: unknown) {
+      this.state = "error";
+      this.errorMessage =
+        err instanceof Error ? err.message : "Failed to generate adventure";
+      this.updateStatus();
+    }
+  }
+
+  private async fetchAdventures(): Promise<void> {
+    try {
+      this.adventures = await listAdventures();
+      this.renderAdventureList();
+    } catch {
+      // Silently ignore list fetch errors — the list is optional
+    }
+  }
+
+  private renderAdventureList(): void {
+    if (!this.container) return;
+
+    const listContainer = this.container.querySelector<HTMLDivElement>(
+      "#menu-adventures-container"
+    );
+    if (!listContainer) return;
+
+    listContainer.innerHTML = "";
+
+    if (this.adventures.length === 0) {
+      const empty = document.createElement("p");
+      empty.textContent = "No adventures yet. Generate one above!";
+      empty.style.cssText = "color: #666; font-size: 13px;";
+      listContainer.appendChild(empty);
+      return;
+    }
+
+    for (const adventure of this.adventures) {
+      const item = document.createElement("div");
+      item.className = "menu-adventure-item";
+      item.dataset.adventureId = adventure.id;
+      item.style.cssText = `
+        padding: 12px 16px;
+        margin-bottom: 8px;
+        background: #2a2a3e;
+        border: 1px solid #333;
+        border-radius: 6px;
+        cursor: pointer;
+        transition: border-color 0.2s;
+      `;
+
+      const itemTitle = document.createElement("div");
+      itemTitle.textContent = adventure.title || "Untitled Adventure";
+      itemTitle.style.cssText = "font-size: 15px; color: #e0e0e0; margin-bottom: 4px;";
+      item.appendChild(itemTitle);
+
+      const itemPrompt = document.createElement("div");
+      itemPrompt.textContent = adventure.prompt;
+      itemPrompt.style.cssText = `
+        font-size: 12px;
+        color: #888;
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
+      `;
+      item.appendChild(itemPrompt);
+
+      const statusBadge = document.createElement("span");
+      statusBadge.textContent = adventure.status;
+      statusBadge.style.cssText = `
+        font-size: 11px;
+        padding: 2px 8px;
+        border-radius: 4px;
+        margin-top: 4px;
+        display: inline-block;
+        background: ${adventure.status === "ready" ? "#2d5a27" : adventure.status === "generating" ? "#5a4a27" : "#5a2727"};
+        color: ${adventure.status === "ready" ? "#7bc67b" : adventure.status === "generating" ? "#c6b67b" : "#c67b7b"};
+      `;
+      item.appendChild(statusBadge);
+
+      if (adventure.status === "ready") {
+        item.addEventListener("click", () => this.navigateToBootScene(adventure.id));
+      } else {
+        item.style.opacity = "0.6";
+        item.style.cursor = "default";
+      }
+
+      listContainer.appendChild(item);
+    }
+  }
+
+  private navigateToBootScene(adventureId?: string): void {
+    this.removeDOM();
+    this.scene.start("BootScene", { adventureId });
+  }
+
+  private removeDOM(): void {
+    if (this.container) {
+      this.container.remove();
+      this.container = null;
+    }
+  }
+}


### PR DESCRIPTION
## Summary
Closes #9

Entry screen with prompt input, adventure generation, list of adventures, and Play Example button.

## Changes
- `src/scenes/MenuScene.ts` — DOM-based menu with generate/list/play example
- `src/scenes/MenuScene.test.ts` — 25 tests
- `src/config.ts` — register MenuScene as first scene

## Test Plan
- `pnpm test` passes (126 tests)