### PR TITLE
Add GameScene integrating all engine components

### DIFF
--- a/src/scenes/GameScene.test.ts
+++ b/src/scenes/GameScene.test.ts
@@ -268,6 +268,30 @@ describe('GameLoop', () => {
       expect(deps.renderScene).toHaveBeenCalledWith(TEST_SCENE_METADATA.scenes['cave']);
     });
 
+    it('should sync Ink story state so hotspots in the new scene work', () => {
+      // Navigate to cave via exit
+      const exit = TEST_SCENE_METADATA.scenes['start'].exits[0];
+      gameLoop.handleExit(exit);
+
+      deps.showText.mockClear();
+      deps.clearScene.mockClear();
+      deps.renderScene.mockClear();
+
+      // Now in cave — the chest hotspot has ink_target 'use(key)'
+      // which should match the cave knot's 'use(key)' choice.
+      // Without the fix, currentChoices would still belong to 'start' and
+      // this interaction would produce "Nothing happens."
+      const caveChoices = gameLoop.getCurrentChoices();
+      expect(caveChoices.some((c) => c.text.includes('Go back'))).toBe(true);
+      expect(caveChoices.some((c) => c.text.includes('use(key)'))).toBe(true);
+
+      // Verify an interaction with a cave hotspot actually works
+      gameLoop.handleInteraction('Go back');
+      expect(deps.showText).toHaveBeenCalledWith(
+        expect.stringContaining('You are on the beach.')
+      );
+    });
+
     it('should show nothing happens when target scene does not exist', () => {
       const exit = {
         direction: 'west' as const,

--- a/src/scenes/GameScene.ts
+++ b/src/scenes/GameScene.ts
@@ -100,7 +100,8 @@ export class GameLoop {
 
   /**
    * Handle left-click on an exit.
-   * Checks requires condition via InkEngine variables, navigates or shows locked message.
+   * Checks requires condition via InkEngine variables, then advances the Ink
+   * story to the target scene's knot before switching the visual scene.
    */
   handleExit(exit: Exit): void {
     if (exit.requires) {
@@ -118,7 +119,19 @@ export class GameLoop {
       return;
     }
 
-    this.switchScene(targetScene, sceneData);
+    // Find and select the Ink choice that navigates to the target scene.
+    // Match by target_scene name appearing in the choice text.
+    const matchIndex = this.findChoiceByTarget(targetScene, this.currentChoices);
+
+    if (matchIndex !== -1) {
+      this.inkEngine.chooseChoice(matchIndex);
+      const result = this.inkEngine.continueStory();
+      this.syncInventory();
+      this.processOutput(result.text, result.choices);
+    } else {
+      // No matching Ink choice found — switch visually only as fallback
+      this.switchScene(targetScene, sceneData);
+    }
   }
 
   /**


### PR DESCRIPTION
## Summary
Closes #8

Main gameplay scene orchestrating InkEngine, SceneRenderer, DialoguePanel, and InventoryBar into a playable game loop.

## Changes
- `src/scenes/GameScene.ts` — GameLoop (testable orchestrator) + GameScene (Phaser wrapper)
- `src/scenes/GameScene.test.ts` — 23 tests with real InkEngine + mocked renderers

## Key Features
- Tag-based scene detection from Ink knots
- Left-click hotspot/character → advance Ink story via ink_target matching
- Right-click → look description
- Exit navigation with requires gate
- Inventory sync from has_* Ink variables
- Use item with hotspot
- END detection with completion message

## Test Plan
- `pnpm test` passes (124 tests)