### PR TITLE
Fix: register all Phaser scenes for correct navigation

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -1,6 +1,7 @@
 import Phaser from 'phaser';
 import { MenuScene } from './scenes/MenuScene';
 import { BootScene } from './scenes/BootScene';
+import { GameScene } from './scenes/GameScene';
 
 export const gameConfig: Phaser.Types.Core.GameConfig = {
   type: Phaser.AUTO,
@@ -8,5 +9,5 @@ export const gameConfig: Phaser.Types.Core.GameConfig = {
   height: 600,
   parent: 'game-container',
   backgroundColor: '#1a1a2e',
-  scene: [MenuScene, BootScene],
+  scene: [MenuScene, BootScene, GameScene],
 };

--- a/src/scenes/BootScene.ts
+++ b/src/scenes/BootScene.ts
@@ -3,9 +3,14 @@ import { loadAdventure } from "./adventure-loader";
 
 export class BootScene extends Phaser.Scene {
   private loadingText: Phaser.GameObjects.Text | null = null;
+  private adventureId: string | undefined;
 
   constructor() {
     super({ key: "BootScene" });
+  }
+
+  init(data: { adventureId?: string }): void {
+    this.adventureId = data.adventureId;
   }
 
   create(): void {
@@ -22,7 +27,7 @@ export class BootScene extends Phaser.Scene {
 
   private async boot(): Promise<void> {
     try {
-      const adventure = await loadAdventure();
+      const adventure = await loadAdventure(this.adventureId);
       this.scene.start("GameScene", { adventure });
     } catch (error: unknown) {
       const message =

--- a/src/scenes/MenuScene.test.ts
+++ b/src/scenes/MenuScene.test.ts
@@ -388,7 +388,7 @@ describe("MenuScene", () => {
       );
 
       expect(configSource).toContain("MenuScene");
-      expect(configSource).toContain("scene: [MenuScene, BootScene]");
+      expect(configSource).toContain("scene: [MenuScene, BootScene, GameScene]");
     });
   });
 });

--- a/src/scenes/adventure-loader.ts
+++ b/src/scenes/adventure-loader.ts
@@ -31,14 +31,14 @@ export function loadStaticAdventure(): Adventure {
 }
 
 /**
- * Loads an adventure either from the Fyso API (if URL param present)
- * or falls back to the static pirate adventure.
+ * Loads an adventure either from the Fyso API (if adventureId provided or
+ * URL param present) or falls back to the static pirate adventure.
  */
-export async function loadAdventure(): Promise<Adventure> {
-  const adventureId = getAdventureIdFromUrl();
+export async function loadAdventure(adventureId?: string): Promise<Adventure> {
+  const resolvedId = adventureId ?? getAdventureIdFromUrl();
 
-  if (adventureId) {
-    return getAdventure(adventureId);
+  if (resolvedId) {
+    return getAdventure(resolvedId);
   }
 
   return loadStaticAdventure();


### PR DESCRIPTION
## Summary
Hotfix: GameScene was not registered in Phaser config, causing "Scene key not found: GameScene" error.

## Changes
- `src/config.ts` — import and register GameScene in scene array
- `src/scenes/BootScene.ts` — accept adventureId from MenuScene
- `src/scenes/adventure-loader.ts` — accept optional adventureId param
- `src/scenes/MenuScene.test.ts` — update config test

## Test Plan
- `pnpm test` passes (159 tests)
- `pnpm build` succeeds
- `pnpm dev` → MenuScene loads → "Play Example" → BootScene → GameScene