### PR TITLE
E2E integration: playable pirate adventure from start to finish

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -1,6 +1,7 @@
 import Phaser from 'phaser';
 import { MenuScene } from './scenes/MenuScene';
 import { BootScene } from './scenes/BootScene';
+import { GameScene } from './scenes/GameScene';
 
 export const gameConfig: Phaser.Types.Core.GameConfig = {
   type: Phaser.AUTO,
@@ -8,5 +9,5 @@ export const gameConfig: Phaser.Types.Core.GameConfig = {
   height: 600,
   parent: 'game-container',
   backgroundColor: '#1a1a2e',
-  scene: [MenuScene, BootScene],
+  scene: [MenuScene, BootScene, GameScene],
 };

--- a/src/e2e.test.ts
+++ b/src/e2e.test.ts
@@ -1,0 +1,214 @@
+import { describe, it, expect, vi } from 'vitest';
+import { InkEngine } from './engine/InkEngine';
+import { loadStaticAdventure } from './scenes/adventure-loader';
+
+vi.mock('phaser', () => ({
+  default: {
+    Scene: class MockScene {},
+  },
+}));
+
+import { GameLoop, GameLoopDeps } from './scenes/GameScene';
+
+function createTrackedDeps(inkEngine: InkEngine, metadata: GameLoopDeps['sceneMetadata']) {
+  const inventory: string[] = [];
+
+  const deps: GameLoopDeps & {
+    showText: ReturnType<typeof vi.fn>;
+    showChoices: ReturnType<typeof vi.fn>;
+    renderScene: ReturnType<typeof vi.fn>;
+    clearScene: ReturnType<typeof vi.fn>;
+    addItem: ReturnType<typeof vi.fn>;
+    removeItem: ReturnType<typeof vi.fn>;
+    getSelectedItem: ReturnType<typeof vi.fn>;
+    clearSelection: ReturnType<typeof vi.fn>;
+    getInventoryItems: ReturnType<typeof vi.fn>;
+  } = {
+    inkEngine,
+    sceneMetadata: metadata,
+    renderScene: vi.fn(),
+    clearScene: vi.fn(),
+    showText: vi.fn(),
+    showChoices: vi.fn(),
+    addItem: vi.fn((item: string) => {
+      if (!inventory.includes(item)) inventory.push(item);
+    }),
+    removeItem: vi.fn((item: string) => {
+      const idx = inventory.indexOf(item);
+      if (idx !== -1) inventory.splice(idx, 1);
+    }),
+    getSelectedItem: vi.fn(() => null),
+    clearSelection: vi.fn(),
+    getInventoryItems: vi.fn(() => [...inventory]),
+  };
+
+  return { deps, inventory };
+}
+
+/**
+ * Helper to find a choice index by partial text match from the GameLoop's
+ * current choices.
+ */
+function findChoice(gameLoop: GameLoop, partialText: string): number {
+  const choices = gameLoop.getCurrentChoices();
+  const match = choices.find((c) =>
+    c.text.toLowerCase().includes(partialText.toLowerCase())
+  );
+  if (match === undefined) {
+    throw new Error(
+      `Choice "${partialText}" not found. Available: ${choices.map((c) => c.text).join(', ')}`
+    );
+  }
+  return match.index;
+}
+
+describe('E2E: Pirate Adventure playthrough', () => {
+  it('plays the pirate adventure from start to finish', () => {
+    const adventure = loadStaticAdventure();
+    const inkEngine = new InkEngine();
+    inkEngine.loadStory(adventure.ink_script);
+
+    const { deps, inventory } = createTrackedDeps(inkEngine, adventure.scene_metadata);
+    const gameLoop = new GameLoop(deps);
+
+    // Start the game
+    gameLoop.start();
+
+    // Verify we begin on the beach
+    expect(deps.showText).toHaveBeenCalledWith(
+      expect.stringContaining('sandy beach')
+    );
+    expect(deps.renderScene).toHaveBeenCalledWith(adventure.scene_metadata.scenes['beach']);
+    expect(gameLoop.getCurrentSceneName()).toBe('beach');
+
+    // Step 1: Look at the ship (via hotspot interaction)
+    gameLoop.handleInteraction('beach_ship');
+    expect(deps.showText).toHaveBeenCalledWith(
+      expect.stringContaining('coil of rope')
+    );
+
+    // Step 2: Take the rope
+    const takeRopeIdx = findChoice(gameLoop, 'Take the rope');
+    gameLoop.handleChoiceSelected(takeRopeIdx);
+    expect(deps.showText).toHaveBeenCalledWith(
+      expect.stringContaining('grab the rope')
+    );
+    // Verify rope variable was set in Ink
+    expect(inkEngine.getVariable('has_rope')).toBe(true);
+    // Verify we are back on the beach
+    expect(gameLoop.getCurrentSceneName()).toBe('beach');
+
+    // Step 3: Go east to the village (via exit)
+    const eastExit = adventure.scene_metadata.scenes['beach'].exits.find(
+      (e) => e.direction === 'east'
+    );
+    expect(eastExit).toBeDefined();
+    gameLoop.handleExit(eastExit!);
+    expect(gameLoop.getCurrentSceneName()).toBe('village');
+
+    // Step 4: Talk to the sailor (via character interaction)
+    gameLoop.handleInteraction('village_sailor');
+    expect(deps.showText).toHaveBeenCalledWith(
+      expect.stringContaining('Arrr')
+    );
+    // Sailor gives has_key = true
+
+    // Step 5: Go west back to the beach
+    const westExit = adventure.scene_metadata.scenes['village'].exits.find(
+      (e) => e.direction === 'west'
+    );
+    expect(westExit).toBeDefined();
+    gameLoop.handleExit(westExit!);
+    expect(gameLoop.getCurrentSceneName()).toBe('beach');
+
+    // Verify has_key is now true (sailor gave it)
+    expect(inkEngine.getVariable('has_key')).toBe(true);
+
+    // Step 6: Go north to the cave (was locked before, now accessible)
+    const northExit = adventure.scene_metadata.scenes['beach'].exits.find(
+      (e) => e.direction === 'north'
+    );
+    expect(northExit).toBeDefined();
+    expect(northExit!.requires).toBe('has_key');
+    gameLoop.handleExit(northExit!);
+    expect(gameLoop.getCurrentSceneName()).toBe('cave');
+
+    // Step 7: Look at the chest (via hotspot interaction)
+    // Since has_rope is true, this triggers the victory path
+    expect(inkEngine.getVariable('has_rope')).toBe(true);
+    gameLoop.handleInteraction('cave_chest');
+
+    // Step 8: The Ink story checks has_rope and delivers victory text + END
+    expect(deps.showText).toHaveBeenCalledWith(
+      expect.stringContaining("Blackbeard's treasure")
+    );
+    expect(deps.showText).toHaveBeenCalledWith(
+      expect.stringContaining('The End.')
+    );
+  });
+
+  it('blocks the cave exit when has_key is false', () => {
+    const adventure = loadStaticAdventure();
+    const inkEngine = new InkEngine();
+    inkEngine.loadStory(adventure.ink_script);
+
+    const { deps } = createTrackedDeps(inkEngine, adventure.scene_metadata);
+    const gameLoop = new GameLoop(deps);
+
+    gameLoop.start();
+
+    // Try to go north without has_key
+    const northExit = adventure.scene_metadata.scenes['beach'].exits.find(
+      (e) => e.direction === 'north'
+    );
+    expect(northExit).toBeDefined();
+
+    deps.showText.mockClear();
+    gameLoop.handleExit(northExit!);
+
+    expect(deps.showText).toHaveBeenCalledWith('You need key to go there.');
+    // Should still be on the beach
+    expect(gameLoop.getCurrentSceneName()).toBe('beach');
+  });
+
+  it('shows "The chest is wedged tight" when looking at chest without rope', () => {
+    const adventure = loadStaticAdventure();
+    const inkEngine = new InkEngine();
+    inkEngine.loadStory(adventure.ink_script);
+
+    const { deps } = createTrackedDeps(inkEngine, adventure.scene_metadata);
+    const gameLoop = new GameLoop(deps);
+
+    gameLoop.start();
+
+    // Go east to village
+    const eastExit = adventure.scene_metadata.scenes['beach'].exits.find(
+      (e) => e.direction === 'east'
+    );
+    gameLoop.handleExit(eastExit!);
+
+    // Talk to sailor (get has_key)
+    gameLoop.handleInteraction('village_sailor');
+
+    // Go west to beach
+    const westExit = adventure.scene_metadata.scenes['village'].exits.find(
+      (e) => e.direction === 'west'
+    );
+    gameLoop.handleExit(westExit!);
+
+    // Go north to cave (has_key is true now)
+    const northExit = adventure.scene_metadata.scenes['beach'].exits.find(
+      (e) => e.direction === 'north'
+    );
+    gameLoop.handleExit(northExit!);
+    expect(gameLoop.getCurrentSceneName()).toBe('cave');
+
+    // Look at chest without rope
+    deps.showText.mockClear();
+    gameLoop.handleInteraction('cave_chest');
+
+    expect(deps.showText).toHaveBeenCalledWith(
+      expect.stringContaining('wedged tight')
+    );
+  });
+});

--- a/src/scenes/BootScene.ts
+++ b/src/scenes/BootScene.ts
@@ -1,11 +1,20 @@
 import Phaser from "phaser";
 import { loadAdventure } from "./adventure-loader";
 
+export interface BootSceneData {
+  adventureId?: string;
+}
+
 export class BootScene extends Phaser.Scene {
   private loadingText: Phaser.GameObjects.Text | null = null;
+  private adventureId: string | undefined;
 
   constructor() {
     super({ key: "BootScene" });
+  }
+
+  init(data: BootSceneData): void {
+    this.adventureId = data.adventureId;
   }
 
   create(): void {
@@ -22,7 +31,7 @@ export class BootScene extends Phaser.Scene {
 
   private async boot(): Promise<void> {
     try {
-      const adventure = await loadAdventure();
+      const adventure = await loadAdventure(this.adventureId);
       this.scene.start("GameScene", { adventure });
     } catch (error: unknown) {
       const message =

--- a/src/scenes/GameScene.test.ts
+++ b/src/scenes/GameScene.test.ts
@@ -248,7 +248,7 @@ describe('GameLoop', () => {
       };
       gameLoop.handleExit(exit);
 
-      expect(deps.showText).toHaveBeenCalledWith('The way east is blocked.');
+      expect(deps.showText).toHaveBeenCalledWith('You need key to go there.');
       expect(deps.renderScene).not.toHaveBeenCalled();
     });
 

--- a/src/scenes/GameScene.ts
+++ b/src/scenes/GameScene.ts
@@ -107,7 +107,8 @@ export class GameLoop {
     if (exit.requires) {
       const value = this.inkEngine.getVariable(exit.requires);
       if (!value) {
-        this.showTextFn(`The way ${exit.direction} is blocked.`);
+        const itemName = exit.requires.replace(/^has_/, '');
+        this.showTextFn(`You need ${itemName} to go there.`);
         return;
       }
     }
@@ -192,17 +193,78 @@ export class GameLoop {
   }
 
   /**
-   * Detect scene name from Ink tags.
-   * Convention: a tag matching a key in sceneMetadata.scenes indicates the current scene.
+   * Detect scene name from Ink tags, or as a fallback, from the available
+   * choices matching a scene's hotspot/character ink_targets or exit targets.
    */
   private detectSceneFromTags(): string | null {
+    // Primary: match by Ink tags
     const tags = this.inkEngine.getCurrentTags();
     for (const tag of tags) {
       if (this.sceneMetadata.scenes[tag]) {
         return tag;
       }
     }
-    return null;
+
+    // Fallback: match by choice text containing scene-specific ink_targets
+    return this.detectSceneFromChoices();
+  }
+
+  /**
+   * Detect the current scene by matching available choices against
+   * hotspot/character ink_targets and exit target_scenes defined in metadata.
+   * Returns the scene with the most matches, or null if none found.
+   */
+  private detectSceneFromChoices(): string | null {
+    const choiceTexts = this.currentChoices.map((c) => c.text.toLowerCase());
+    if (choiceTexts.length === 0) return null;
+
+    let bestScene: string | null = null;
+    let bestScore = 0;
+
+    for (const [sceneName, sceneData] of Object.entries(this.sceneMetadata.scenes)) {
+      let score = 0;
+
+      for (const hotspot of sceneData.hotspots) {
+        const target = hotspot.ink_target.replace(/_/g, ' ').toLowerCase();
+        const label = hotspot.label.toLowerCase();
+        const labelWords = label.split(/\s+/).filter((w) => w.length >= 4);
+        if (choiceTexts.some((ct) =>
+          ct.includes(target) ||
+          ct.includes(hotspot.ink_target.toLowerCase()) ||
+          ct.includes(label) ||
+          labelWords.some((w) => ct.includes(w))
+        )) {
+          score++;
+        }
+      }
+
+      for (const character of sceneData.characters) {
+        const target = character.ink_target.replace(/_/g, ' ').toLowerCase();
+        const label = character.label.toLowerCase();
+        const labelWords = label.split(/\s+/).filter((w) => w.length >= 4);
+        if (choiceTexts.some((ct) =>
+          ct.includes(target) ||
+          ct.includes(character.ink_target.toLowerCase()) ||
+          ct.includes(label) ||
+          labelWords.some((w) => ct.includes(w))
+        )) {
+          score++;
+        }
+      }
+
+      for (const exit of sceneData.exits) {
+        if (choiceTexts.some((ct) => ct.includes(exit.target_scene.toLowerCase()))) {
+          score++;
+        }
+      }
+
+      if (score > bestScore) {
+        bestScore = score;
+        bestScene = sceneName;
+      }
+    }
+
+    return bestScene;
   }
 
   /**
@@ -280,6 +342,16 @@ export class GameLoop {
       c.text.toLowerCase().includes(normalized)
     );
     if (normalizedMatch) return normalizedMatch.index;
+
+    // Try matching just the suffix after the scene prefix (e.g. "beach_ship" -> "ship")
+    const underscoreIdx = inkTarget.indexOf('_');
+    if (underscoreIdx !== -1) {
+      const suffix = inkTarget.slice(underscoreIdx + 1).replace(/_/g, ' ').toLowerCase();
+      const suffixMatch = choices.find((c) =>
+        c.text.toLowerCase().includes(suffix)
+      );
+      if (suffixMatch) return suffixMatch.index;
+    }
 
     return -1;
   }

--- a/src/scenes/MenuScene.test.ts
+++ b/src/scenes/MenuScene.test.ts
@@ -388,7 +388,7 @@ describe("MenuScene", () => {
       );
 
       expect(configSource).toContain("MenuScene");
-      expect(configSource).toContain("scene: [MenuScene, BootScene]");
+      expect(configSource).toContain("scene: [MenuScene, BootScene, GameScene]");
     });
   });
 });

--- a/src/scenes/adventure-loader.ts
+++ b/src/scenes/adventure-loader.ts
@@ -31,14 +31,14 @@ export function loadStaticAdventure(): Adventure {
 }
 
 /**
- * Loads an adventure either from the Fyso API (if URL param present)
- * or falls back to the static pirate adventure.
+ * Loads an adventure either from the Fyso API (if an ID is provided or
+ * present in the URL) or falls back to the static pirate adventure.
  */
-export async function loadAdventure(): Promise<Adventure> {
-  const adventureId = getAdventureIdFromUrl();
+export async function loadAdventure(adventureId?: string): Promise<Adventure> {
+  const id = adventureId ?? getAdventureIdFromUrl();
 
-  if (adventureId) {
-    return getAdventure(adventureId);
+  if (id) {
+    return getAdventure(id);
   }
 
   return loadStaticAdventure();


### PR DESCRIPTION
## Summary
Closes #13

Wires all components together for a fully playable pirate adventure. Includes E2E integration test with complete playthrough.

## Changes
- `src/config.ts` — register all 3 scenes
- `src/scenes/BootScene.ts` — accept adventureId from MenuScene
- `src/scenes/adventure-loader.ts` — optional adventureId param
- `src/scenes/GameScene.ts` — locked exit message fix, scene detection fallback, choice suffix matching
- `src/e2e.test.ts` — full playthrough test (beach → village → cave → treasure → END)

## Test Plan
- `pnpm test` passes (162 tests)
- `pnpm build` produces dist/
- E2E test verifies complete pirate adventure playthrough