### PR TITLE
Fix visual rendering: hotspots, characters, exits, inventory

### DIFF
--- a/src/engine/DialoguePanel.ts
+++ b/src/engine/DialoguePanel.ts
@@ -65,8 +65,13 @@ export class DialoguePanel {
   showChoices(choices: string[]): void {
     this.clearChoices();
 
+    // Stack choices below narrative text if present
+    const baseY = this.narrativeText
+      ? this.narrativeText.y + this.narrativeText.height + 8
+      : PANEL_Y + TEXT_PADDING_Y;
+
     choices.forEach((choice, index) => {
-      const y = PANEL_Y + TEXT_PADDING_Y + index * CHOICE_LINE_HEIGHT;
+      const y = baseY + index * CHOICE_LINE_HEIGHT;
       const choiceText = this.scene.add.text(
         TEXT_PADDING_X,
         y,

--- a/src/engine/SceneRenderer.test.ts
+++ b/src/engine/SceneRenderer.test.ts
@@ -48,6 +48,7 @@ function createMockGameObject() {
     setInteractive: vi.fn().mockReturnThis(),
     setOrigin: vi.fn().mockReturnThis(),
     setAlpha: vi.fn().mockReturnThis(),
+    setDepth: vi.fn().mockReturnThis(),
     destroy: vi.fn(),
     input: { cursor: '' },
     on: vi.fn((event: string, callback: (...args: unknown[]) => void) => {

--- a/src/engine/SceneRenderer.ts
+++ b/src/engine/SceneRenderer.ts
@@ -113,6 +113,7 @@ export class SceneRenderer {
       CANVAS_HEIGHT,
       hex,
     );
+    bg.setDepth(0);
     this.gameObjects.push(bg);
   }
 
@@ -125,6 +126,7 @@ export class SceneRenderer {
     const rect = this.scene.add.rectangle(x, y, w, h);
     rect.setStrokeStyle(2, HOTSPOT_BORDER_COLOR, HOTSPOT_BORDER_ALPHA);
     rect.setFillStyle(HOTSPOT_BORDER_COLOR, HOTSPOT_FILL_ALPHA);
+    rect.setDepth(10);
     rect.setInteractive({ useHandCursor: true });
 
     rect.on('pointerover', () => {
@@ -150,6 +152,7 @@ export class SceneRenderer {
       color: LABEL_COLOR,
     });
     label.setOrigin(0.5, 1);
+    label.setDepth(11);
 
     this.gameObjects.push(rect, label);
   }
@@ -159,6 +162,7 @@ export class SceneRenderer {
     const y = toCanvasY(character.y);
 
     const circle = this.scene.add.circle(x, y, CHARACTER_RADIUS, CHARACTER_COLOR);
+    circle.setDepth(10);
     circle.setInteractive(
       new Phaser.Geom.Circle(0, 0, CHARACTER_RADIUS),
       Phaser.Geom.Circle.Contains,
@@ -188,6 +192,7 @@ export class SceneRenderer {
       color: LABEL_COLOR,
     });
     label.setOrigin(0.5, 1);
+    label.setDepth(11);
 
     this.gameObjects.push(circle, label);
   }
@@ -204,6 +209,7 @@ export class SceneRenderer {
       fontStyle: 'bold',
     });
     text.setOrigin(0.5, 0.5);
+    text.setDepth(12);
     text.setInteractive({ useHandCursor: true });
 
     text.on('pointerover', () => {

--- a/src/scenes/GameScene.ts
+++ b/src/scenes/GameScene.ts
@@ -180,6 +180,27 @@ export class GameLoop {
       }
     }
 
+    // If no scene has been rendered yet (e.g. story lacks # tags),
+    // detect the initial scene by matching choice targets to scene metadata.
+    if (!this.currentSceneName) {
+      const initialScene = this.detectSceneFromChoices(choices);
+      if (initialScene) {
+        const sceneData = this.sceneMetadata.scenes[initialScene];
+        if (sceneData) {
+          this.switchScene(initialScene, sceneData);
+        }
+      } else {
+        // Last resort: render the first scene in metadata
+        const firstSceneName = Object.keys(this.sceneMetadata.scenes)[0];
+        if (firstSceneName) {
+          const sceneData = this.sceneMetadata.scenes[firstSceneName];
+          if (sceneData) {
+            this.switchScene(firstSceneName, sceneData);
+          }
+        }
+      }
+    }
+
     if (text) {
       this.showTextFn(text);
     }
@@ -203,6 +224,50 @@ export class GameLoop {
       }
     }
     return null;
+  }
+
+  /**
+   * Detect scene name by matching available choices against scene metadata.
+   * If choices reference hotspot ink_targets or exit target_scenes for a
+   * specific scene, that scene is likely the current one.
+   */
+  private detectSceneFromChoices(
+    choices: Array<{ index: number; text: string }>
+  ): string | null {
+    const choiceTexts = choices.map((c) => c.text.toLowerCase());
+    let bestScene: string | null = null;
+    let bestScore = 0;
+
+    for (const [sceneName, sceneData] of Object.entries(
+      this.sceneMetadata.scenes
+    )) {
+      let score = 0;
+
+      for (const hotspot of sceneData.hotspots) {
+        const target = hotspot.ink_target.replace(/_/g, ' ').toLowerCase();
+        if (
+          choiceTexts.some(
+            (ct) => ct.includes(target) || ct.includes(hotspot.ink_target.toLowerCase())
+          )
+        ) {
+          score += 1;
+        }
+      }
+
+      for (const exit of sceneData.exits) {
+        const targetScene = exit.target_scene.toLowerCase();
+        if (choiceTexts.some((ct) => ct.includes(targetScene))) {
+          score += 1;
+        }
+      }
+
+      if (score > bestScore) {
+        bestScore = score;
+        bestScene = sceneName;
+      }
+    }
+
+    return bestScene;
   }
 
   /**
@@ -318,16 +383,30 @@ export class GameLoop {
  */
 export class GameScene extends Phaser.Scene {
   private gameLoop: GameLoop | null = null;
+  private adventureData: Adventure | null = null;
 
   constructor() {
     super({ key: 'GameScene' });
   }
 
   init(data: GameSceneData): void {
-    const { adventure } = data;
+    this.adventureData = data.adventure;
+  }
+
+  create(): void {
+    const adventure = this.adventureData;
+    if (!adventure) {
+      return;
+    }
 
     const inkEngine = new InkEngine();
     inkEngine.loadStory(adventure.ink_script);
+
+    // Parse scene_metadata if it arrives as a string (e.g. from Fyso API)
+    const sceneMetadata: SceneMetadata =
+      typeof adventure.scene_metadata === 'string'
+        ? (JSON.parse(adventure.scene_metadata) as SceneMetadata)
+        : adventure.scene_metadata;
 
     const sceneRenderer = new SceneRenderer(this);
     const dialoguePanel = new DialoguePanel(this);
@@ -338,7 +417,7 @@ export class GameScene extends Phaser.Scene {
 
     this.gameLoop = new GameLoop({
       inkEngine,
-      sceneMetadata: adventure.scene_metadata,
+      sceneMetadata,
       renderScene: (sceneData) => sceneRenderer.renderScene(sceneData),
       clearScene: () => sceneRenderer.clearScene(),
       showText: (text) => dialoguePanel.showText(text),
@@ -374,9 +453,7 @@ export class GameScene extends Phaser.Scene {
     dialoguePanel.onChoiceSelected((index) => {
       this.gameLoop?.handleChoiceSelected(index);
     });
-  }
 
-  create(): void {
-    this.gameLoop?.start();
+    this.gameLoop.start();
   }
 }


### PR DESCRIPTION
## Summary
Closes #29

Fixes all visual rendering issues so the game looks like a LucasArts point-and-click adventure.

## Root causes fixed
1. Game objects created in `init()` instead of `create()` — Phaser display list not ready
2. No scene rendered when Ink lacks `#` tags — added choice-based scene detection
3. Dialogue text corruption — overlapping text positions fixed
4. Missing depth/z-order on scene objects — proper layering added
5. scene_metadata string handling — JSON.parse fallback
6. Test mocks updated for new depth calls

## Test Plan
- `pnpm test` passes (159 tests)
- `pnpm build` succeeds
- Visual: background color, hotspot rectangles, character circles, exit arrows, inventory bar, clean dialogue text