### PR TITLE
Add BubbleText for floating interaction text

### DIFF
--- a/src/engine/BubbleText.test.ts
+++ b/src/engine/BubbleText.test.ts
@@ -1,0 +1,296 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { BubbleText } from './BubbleText';
+
+function createMockText(overrides?: Partial<{ width: number; height: number }>) {
+  const handlers: Record<string, (() => void)[]> = {};
+  return {
+    width: overrides?.width ?? 100,
+    height: overrides?.height ?? 16,
+    setDepth: vi.fn().mockReturnThis(),
+    setPosition: vi.fn().mockReturnThis(),
+    setInteractive: vi.fn().mockReturnThis(),
+    setColor: vi.fn().mockReturnThis(),
+    destroy: vi.fn(),
+    on: vi.fn((event: string, handler: () => void) => {
+      if (!handlers[event]) handlers[event] = [];
+      handlers[event].push(handler);
+    }),
+    _handlers: handlers,
+    _emit(event: string) {
+      if (handlers[event]) handlers[event].forEach((h) => h());
+    },
+  };
+}
+
+function createMockGraphics() {
+  return {
+    fillStyle: vi.fn().mockReturnThis(),
+    fillRoundedRect: vi.fn().mockReturnThis(),
+    destroy: vi.fn(),
+  };
+}
+
+function createMockContainer() {
+  const handlers: Record<string, (() => void)[]> = {};
+  return {
+    setDepth: vi.fn().mockReturnThis(),
+    setSize: vi.fn().mockReturnThis(),
+    setInteractive: vi.fn().mockReturnThis(),
+    destroy: vi.fn(),
+    on: vi.fn((event: string, handler: () => void) => {
+      if (!handlers[event]) handlers[event] = [];
+      handlers[event].push(handler);
+    }),
+    _handlers: handlers,
+    _emit(event: string) {
+      if (handlers[event]) handlers[event].forEach((h) => h());
+    },
+  };
+}
+
+function createMockTimerEvent() {
+  return {
+    remove: vi.fn(),
+  };
+}
+
+function createMockScene() {
+  const textObjects: ReturnType<typeof createMockText>[] = [];
+  const containers: ReturnType<typeof createMockContainer>[] = [];
+  const timers: ReturnType<typeof createMockTimerEvent>[] = [];
+  const timerCallbacks: (() => void)[] = [];
+
+  return {
+    add: {
+      text: vi.fn((_x: number, _y: number, _text: string, _style: Record<string, unknown>) => {
+        const t = createMockText();
+        textObjects.push(t);
+        return t;
+      }),
+      graphics: vi.fn(() => createMockGraphics()),
+      container: vi.fn((_x: number, _y: number, _children: unknown[]) => {
+        const c = createMockContainer();
+        containers.push(c);
+        return c;
+      }),
+    },
+    time: {
+      addEvent: vi.fn((config: { delay: number; callback: () => void }) => {
+        timerCallbacks.push(config.callback);
+        const timer = createMockTimerEvent();
+        timers.push(timer);
+        return timer;
+      }),
+    },
+    _textObjects: textObjects,
+    _containers: containers,
+    _timers: timers,
+    _timerCallbacks: timerCallbacks,
+  };
+}
+
+describe('BubbleText', () => {
+  let scene: ReturnType<typeof createMockScene>;
+  let bubbleText: BubbleText;
+
+  beforeEach(() => {
+    scene = createMockScene();
+    bubbleText = new BubbleText(scene as unknown as Phaser.Scene);
+  });
+
+  describe('showBubble', () => {
+    it('should create a text object with correct style', () => {
+      bubbleText.showBubble(100, 200, 'Hello world');
+
+      expect(scene.add.text).toHaveBeenCalledWith(
+        0,
+        0,
+        'Hello world',
+        expect.objectContaining({
+          fontFamily: 'monospace',
+          fontSize: '13px',
+          color: '#e0e0e0',
+        })
+      );
+    });
+
+    it('should create a graphics background', () => {
+      bubbleText.showBubble(100, 200, 'Test');
+
+      expect(scene.add.graphics).toHaveBeenCalledTimes(1);
+    });
+
+    it('should create a container at world position', () => {
+      bubbleText.showBubble(100, 200, 'Test');
+
+      expect(scene.add.container).toHaveBeenCalledTimes(1);
+      expect(scene.add.container).toHaveBeenCalledWith(
+        expect.any(Number),
+        expect.any(Number),
+        expect.any(Array)
+      );
+    });
+
+    it('should set container depth to 1500', () => {
+      bubbleText.showBubble(100, 200, 'Test');
+
+      const container = scene._containers[0];
+      expect(container.setDepth).toHaveBeenCalledWith(1500);
+    });
+
+    it('should set up auto-dismiss timer with default duration', () => {
+      bubbleText.showBubble(100, 200, 'Test');
+
+      expect(scene.time.addEvent).toHaveBeenCalledWith(
+        expect.objectContaining({ delay: 3000 })
+      );
+    });
+
+    it('should set up auto-dismiss timer with custom duration', () => {
+      bubbleText.showBubble(100, 200, 'Test', 5000);
+
+      expect(scene.time.addEvent).toHaveBeenCalledWith(
+        expect.objectContaining({ delay: 5000 })
+      );
+    });
+
+    it('should auto-dismiss when timer fires', () => {
+      bubbleText.showBubble(100, 200, 'Test');
+
+      const container = scene._containers[0];
+      scene._timerCallbacks[0]();
+
+      expect(container.destroy).toHaveBeenCalled();
+    });
+
+    it('should dismiss on click', () => {
+      bubbleText.showBubble(100, 200, 'Test');
+
+      const container = scene._containers[0];
+      expect(container.setInteractive).toHaveBeenCalled();
+
+      container._emit('pointerdown');
+      expect(container.destroy).toHaveBeenCalled();
+    });
+
+    it('should remove timer when dismissed by click', () => {
+      bubbleText.showBubble(100, 200, 'Test');
+
+      const timer = scene._timers[0];
+      scene._containers[0]._emit('pointerdown');
+
+      expect(timer.remove).toHaveBeenCalled();
+    });
+  });
+
+  describe('showNamedBubble', () => {
+    it('should create name text with yellow bold style', () => {
+      bubbleText.showNamedBubble(100, 200, 'Guard', 'Halt!');
+
+      expect(scene.add.text).toHaveBeenCalledWith(
+        0,
+        0,
+        'Guard',
+        expect.objectContaining({
+          color: '#f1c40f',
+          fontStyle: 'bold',
+        })
+      );
+    });
+
+    it('should create body text with standard style', () => {
+      bubbleText.showNamedBubble(100, 200, 'Guard', 'Halt!');
+
+      expect(scene.add.text).toHaveBeenCalledWith(
+        0,
+        0,
+        'Halt!',
+        expect.objectContaining({
+          fontFamily: 'monospace',
+          fontSize: '13px',
+          color: '#e0e0e0',
+        })
+      );
+    });
+
+    it('should create both name and body text objects', () => {
+      bubbleText.showNamedBubble(100, 200, 'Guard', 'Halt!');
+
+      expect(scene.add.text).toHaveBeenCalledTimes(2);
+    });
+
+    it('should create container with depth 1500', () => {
+      bubbleText.showNamedBubble(100, 200, 'Guard', 'Halt!');
+
+      const container = scene._containers[0];
+      expect(container.setDepth).toHaveBeenCalledWith(1500);
+    });
+
+    it('should set up auto-dismiss timer', () => {
+      bubbleText.showNamedBubble(100, 200, 'Guard', 'Halt!', 4000);
+
+      expect(scene.time.addEvent).toHaveBeenCalledWith(
+        expect.objectContaining({ delay: 4000 })
+      );
+    });
+  });
+
+  describe('multiple bubbles', () => {
+    it('should support multiple bubbles coexisting', () => {
+      bubbleText.showBubble(100, 200, 'First');
+      bubbleText.showBubble(300, 200, 'Second');
+
+      expect(scene._containers).toHaveLength(2);
+    });
+
+    it('should not destroy other bubbles when one is dismissed', () => {
+      bubbleText.showBubble(100, 200, 'First');
+      bubbleText.showBubble(300, 200, 'Second');
+
+      scene._containers[0]._emit('pointerdown');
+
+      expect(scene._containers[0].destroy).toHaveBeenCalled();
+      expect(scene._containers[1].destroy).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('clearAll', () => {
+    it('should remove all active bubbles', () => {
+      bubbleText.showBubble(100, 200, 'First');
+      bubbleText.showBubble(300, 200, 'Second');
+      bubbleText.showNamedBubble(500, 200, 'NPC', 'Third');
+
+      bubbleText.clearAll();
+
+      for (const container of scene._containers) {
+        expect(container.destroy).toHaveBeenCalled();
+      }
+      for (const timer of scene._timers) {
+        expect(timer.remove).toHaveBeenCalled();
+      }
+    });
+
+    it('should handle clearAll when no bubbles exist', () => {
+      expect(() => bubbleText.clearAll()).not.toThrow();
+    });
+
+    it('should handle clearAll after bubbles already dismissed', () => {
+      bubbleText.showBubble(100, 200, 'Test');
+      scene._containers[0]._emit('pointerdown');
+
+      expect(() => bubbleText.clearAll()).not.toThrow();
+    });
+  });
+
+  describe('double dismiss protection', () => {
+    it('should not destroy a bubble twice when clicked after timer fires', () => {
+      bubbleText.showBubble(100, 200, 'Test');
+
+      const container = scene._containers[0];
+      scene._timerCallbacks[0]();
+      container._emit('pointerdown');
+
+      expect(container.destroy).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/src/engine/BubbleText.ts
+++ b/src/engine/BubbleText.ts
@@ -1,0 +1,147 @@
+import Phaser from 'phaser';
+
+const BUBBLE_DEPTH = 1500;
+const BUBBLE_BG_COLOR = 0x1a1a2e;
+const BUBBLE_BG_ALPHA = 0.9;
+const BUBBLE_PADDING_X = 12;
+const BUBBLE_PADDING_Y = 10;
+const BUBBLE_CORNER_RADIUS = 8;
+const BUBBLE_MAX_WIDTH = 250;
+const BUBBLE_DEFAULT_DURATION = 3000;
+const TEXT_COLOR = '#e0e0e0';
+const TEXT_FONT_SIZE = '13px';
+const TEXT_FONT_FAMILY = 'monospace';
+const NAME_COLOR = '#f1c40f';
+
+interface BubbleEntry {
+  container: Phaser.GameObjects.Container;
+  timer: Phaser.Time.TimerEvent;
+}
+
+export class BubbleText {
+  private scene: Phaser.Scene;
+  private activeBubbles: BubbleEntry[] = [];
+
+  constructor(scene: Phaser.Scene) {
+    this.scene = scene;
+  }
+
+  showBubble(x: number, y: number, text: string, duration?: number): void {
+    const effectiveDuration = duration ?? BUBBLE_DEFAULT_DURATION;
+
+    const textObject = this.scene.add.text(0, 0, text, {
+      fontFamily: TEXT_FONT_FAMILY,
+      fontSize: TEXT_FONT_SIZE,
+      color: TEXT_COLOR,
+      wordWrap: { width: BUBBLE_MAX_WIDTH - BUBBLE_PADDING_X * 2 },
+    });
+
+    const bgWidth = Math.min(textObject.width + BUBBLE_PADDING_X * 2, BUBBLE_MAX_WIDTH);
+    const bgHeight = textObject.height + BUBBLE_PADDING_Y * 2;
+
+    const background = this.scene.add.graphics();
+    background.fillStyle(BUBBLE_BG_COLOR, BUBBLE_BG_ALPHA);
+    background.fillRoundedRect(0, 0, bgWidth, bgHeight, BUBBLE_CORNER_RADIUS);
+
+    textObject.setPosition(BUBBLE_PADDING_X, BUBBLE_PADDING_Y);
+
+    const container = this.scene.add.container(x - bgWidth / 2, y - bgHeight, [
+      background,
+      textObject,
+    ]);
+    container.setDepth(BUBBLE_DEPTH);
+    container.setSize(bgWidth, bgHeight);
+    container.setInteractive();
+
+    const entry: BubbleEntry = {
+      container,
+      timer: this.scene.time.addEvent({
+        delay: effectiveDuration,
+        callback: () => this.removeBubble(entry),
+      }),
+    };
+
+    container.on('pointerdown', () => {
+      this.removeBubble(entry);
+    });
+
+    this.activeBubbles.push(entry);
+  }
+
+  showNamedBubble(
+    x: number,
+    y: number,
+    name: string,
+    text: string,
+    duration?: number
+  ): void {
+    const effectiveDuration = duration ?? BUBBLE_DEFAULT_DURATION;
+
+    const nameObject = this.scene.add.text(0, 0, name, {
+      fontFamily: TEXT_FONT_FAMILY,
+      fontSize: TEXT_FONT_SIZE,
+      color: NAME_COLOR,
+      fontStyle: 'bold',
+      wordWrap: { width: BUBBLE_MAX_WIDTH - BUBBLE_PADDING_X * 2 },
+    });
+
+    const textObject = this.scene.add.text(0, 0, text, {
+      fontFamily: TEXT_FONT_FAMILY,
+      fontSize: TEXT_FONT_SIZE,
+      color: TEXT_COLOR,
+      wordWrap: { width: BUBBLE_MAX_WIDTH - BUBBLE_PADDING_X * 2 },
+    });
+
+    const contentWidth = Math.max(nameObject.width, textObject.width);
+    const bgWidth = Math.min(contentWidth + BUBBLE_PADDING_X * 2, BUBBLE_MAX_WIDTH);
+    const nameHeight = nameObject.height;
+    const gapBetween = 4;
+    const bgHeight = BUBBLE_PADDING_Y + nameHeight + gapBetween + textObject.height + BUBBLE_PADDING_Y;
+
+    const background = this.scene.add.graphics();
+    background.fillStyle(BUBBLE_BG_COLOR, BUBBLE_BG_ALPHA);
+    background.fillRoundedRect(0, 0, bgWidth, bgHeight, BUBBLE_CORNER_RADIUS);
+
+    nameObject.setPosition(BUBBLE_PADDING_X, BUBBLE_PADDING_Y);
+    textObject.setPosition(BUBBLE_PADDING_X, BUBBLE_PADDING_Y + nameHeight + gapBetween);
+
+    const container = this.scene.add.container(x - bgWidth / 2, y - bgHeight, [
+      background,
+      nameObject,
+      textObject,
+    ]);
+    container.setDepth(BUBBLE_DEPTH);
+    container.setSize(bgWidth, bgHeight);
+    container.setInteractive();
+
+    const entry: BubbleEntry = {
+      container,
+      timer: this.scene.time.addEvent({
+        delay: effectiveDuration,
+        callback: () => this.removeBubble(entry),
+      }),
+    };
+
+    container.on('pointerdown', () => {
+      this.removeBubble(entry);
+    });
+
+    this.activeBubbles.push(entry);
+  }
+
+  clearAll(): void {
+    const bubbles = [...this.activeBubbles];
+    for (const entry of bubbles) {
+      this.removeBubble(entry);
+    }
+  }
+
+  private removeBubble(entry: BubbleEntry): void {
+    const index = this.activeBubbles.indexOf(entry);
+    if (index === -1) return;
+
+    entry.timer.remove();
+    entry.container.destroy();
+    this.activeBubbles.splice(index, 1);
+  }
+}


### PR DESCRIPTION
## Summary
Closes #46

Floating text bubbles above hotspots/characters for interactions. Replaces DialoguePanel.

## Changes
- `src/engine/BubbleText.ts` — showBubble, showNamedBubble, clearAll
- `src/engine/BubbleText.test.ts` — 20 tests

## Test Plan
- `pnpm test` passes