### PR TITLE
Add AdventureEngine state machine

### DIFF
--- a/src/engine/AdventureEngine.test.ts
+++ b/src/engine/AdventureEngine.test.ts
@@ -1,0 +1,500 @@
+import { describe, it, expect, vi } from 'vitest';
+import { AdventureEngine } from './AdventureEngine';
+import { AdventureData } from '../types/adventure-v2';
+
+/**
+ * Build a test adventure matching the spec example:
+ * "The Missing USB" — oficina, pasillo, server_room.
+ */
+function buildTestAdventure(): AdventureData {
+  return {
+    title: 'The Missing USB',
+    startScene: 'oficina',
+    items: {
+      usb_drive: { id: 'usb_drive', name: 'USB Drive', description: 'A small black USB drive' },
+      coffee_cup: { id: 'coffee_cup', name: 'Coffee Cup', description: 'A warm cup of coffee' },
+      server_key: { id: 'server_key', name: 'Server Room Key', description: 'A metallic key card' },
+    },
+    scenes: {
+      oficina: {
+        id: 'oficina',
+        map: 'office_main',
+        hotspots: [
+          {
+            id: 'escritorio_ana',
+            position: [4, 3],
+            look: 'A messy desk with papers everywhere.',
+            use: [
+              { text: 'Nothing useful here... just papers.', actions: [] },
+              {
+                condition: { type: 'has', target: 'server_key' },
+                text: 'You plug the key card into the reader. Access granted!',
+                actions: [{ type: 'set', target: 'desk_unlocked' }],
+              },
+            ],
+          },
+          {
+            id: 'cafetera',
+            position: [10, 11],
+            look: 'A coffee machine. There\'s something behind it...',
+            use: [],
+            take: {
+              text: 'You grab the USB drive hidden behind the machine!',
+              actions: [
+                { type: 'get', target: 'usb_drive' },
+                { type: 'remove_hotspot', target: 'cafetera' },
+              ],
+            },
+          },
+          {
+            id: 'puerta_server',
+            position: [23, 12],
+            look: 'A heavy door with a key card reader.',
+            use: [
+              { text: 'It\'s locked. You need a key card.', actions: [] },
+              {
+                condition: { type: 'has', target: 'server_key' },
+                text: 'The door slides open.',
+                actions: [{ type: 'go', target: 'server_room' }],
+              },
+            ],
+          },
+        ],
+        characters: [
+          {
+            id: 'ana',
+            position: [5, 3],
+            sprite: 'char_1',
+            look: 'Ana, the senior developer.',
+            talk: [
+              {
+                condition: { type: 'has', target: 'usb_drive' },
+                text: 'You found it! Talk to Carlos, he has the key.',
+                actions: [{ type: 'set', target: 'talked_to_ana' }],
+              },
+              {
+                text: 'Hey! Have you seen the USB drive?',
+                actions: [],
+              },
+            ],
+          },
+          {
+            id: 'carlos',
+            position: [14, 17],
+            sprite: 'char_2',
+            look: 'Carlos, the sysadmin.',
+            talk: [
+              {
+                condition: { type: 'has', target: 'usb_drive' },
+                text: 'Oh, you found the USB? Here, take the server key.',
+                actions: [{ type: 'get', target: 'server_key' }],
+              },
+              {
+                text: 'I\'m busy. Come back later.',
+                actions: [],
+              },
+            ],
+          },
+        ],
+        exits: [
+          {
+            id: 'pasillo_norte',
+            position: [12, 0],
+            target: 'pasillo',
+            look: 'A corridor leading north.',
+          },
+        ],
+      },
+      pasillo: {
+        id: 'pasillo',
+        map: 'corridor',
+        hotspots: [],
+        characters: [],
+        exits: [
+          {
+            id: 'oficina_sur',
+            position: [12, 24],
+            target: 'oficina',
+            look: 'Back to the main office.',
+          },
+          {
+            id: 'server_room_este',
+            position: [24, 12],
+            target: 'server_room',
+            requires: 'server_key',
+            locked: 'You need a key card to enter.',
+            look: 'The server room entrance.',
+          },
+        ],
+      },
+      server_room: {
+        id: 'server_room',
+        map: 'server',
+        hotspots: [
+          {
+            id: 'servidor_principal',
+            position: [12, 12],
+            look: 'The main server rack. There\'s a USB port.',
+            use: [
+              {
+                condition: { type: 'has', target: 'usb_drive' },
+                text: 'You insert the USB and deploy the fix!',
+                actions: [{ type: 'win' }],
+              },
+            ],
+          },
+        ],
+        characters: [],
+        exits: [],
+      },
+    },
+  };
+}
+
+describe('AdventureEngine', () => {
+  // --- Initialization ---
+
+  it('should initialize with the start scene', () => {
+    const engine = new AdventureEngine(buildTestAdventure());
+    expect(engine.getState().currentScene).toBe('oficina');
+  });
+
+  it('should start with empty inventory', () => {
+    const engine = new AdventureEngine(buildTestAdventure());
+    expect(engine.getInventory()).toEqual([]);
+  });
+
+  it('should start with no flags', () => {
+    const engine = new AdventureEngine(buildTestAdventure());
+    expect(engine.hasFlag('anything')).toBe(false);
+  });
+
+  it('should return the current scene definition', () => {
+    const engine = new AdventureEngine(buildTestAdventure());
+    const scene = engine.getCurrentScene();
+    expect(scene.id).toBe('oficina');
+    expect(scene.map).toBe('office_main');
+  });
+
+  // --- Inventory ---
+
+  it('should add items to inventory via get action', () => {
+    const engine = new AdventureEngine(buildTestAdventure());
+    engine.executeActions([{ type: 'get', target: 'usb_drive' }]);
+    expect(engine.hasItem('usb_drive')).toBe(true);
+    expect(engine.getInventory()).toContain('usb_drive');
+  });
+
+  it('should not duplicate items in inventory', () => {
+    const engine = new AdventureEngine(buildTestAdventure());
+    engine.executeActions([{ type: 'get', target: 'usb_drive' }]);
+    engine.executeActions([{ type: 'get', target: 'usb_drive' }]);
+    expect(engine.getInventory().filter((i) => i === 'usb_drive').length).toBe(1);
+  });
+
+  it('should remove items from inventory via remove action', () => {
+    const engine = new AdventureEngine(buildTestAdventure());
+    engine.executeActions([{ type: 'get', target: 'usb_drive' }]);
+    expect(engine.hasItem('usb_drive')).toBe(true);
+    engine.executeActions([{ type: 'remove', target: 'usb_drive' }]);
+    expect(engine.hasItem('usb_drive')).toBe(false);
+  });
+
+  it('should handle removing non-existent item gracefully', () => {
+    const engine = new AdventureEngine(buildTestAdventure());
+    engine.executeActions([{ type: 'remove', target: 'nonexistent' }]);
+    expect(engine.getInventory()).toEqual([]);
+  });
+
+  // --- Flags ---
+
+  it('should set flags via set action', () => {
+    const engine = new AdventureEngine(buildTestAdventure());
+    engine.executeActions([{ type: 'set', target: 'talked_to_ana' }]);
+    expect(engine.hasFlag('talked_to_ana')).toBe(true);
+  });
+
+  it('should report false for unset flags', () => {
+    const engine = new AdventureEngine(buildTestAdventure());
+    expect(engine.hasFlag('nonexistent_flag')).toBe(false);
+  });
+
+  // --- Hotspot interaction ---
+
+  it('should return default use text for hotspot without item', () => {
+    const engine = new AdventureEngine(buildTestAdventure());
+    const result = engine.interactHotspot('escritorio_ana');
+    expect(result).not.toBeNull();
+    expect(result!.text).toBe('Nothing useful here... just papers.');
+  });
+
+  it('should return conditional use text when item matches', () => {
+    const engine = new AdventureEngine(buildTestAdventure());
+    engine.executeActions([{ type: 'get', target: 'server_key' }]);
+    const result = engine.interactHotspot('escritorio_ana', 'server_key');
+    expect(result).not.toBeNull();
+    expect(result!.text).toContain('Access granted');
+  });
+
+  it('should return null when using wrong item on hotspot', () => {
+    const engine = new AdventureEngine(buildTestAdventure());
+    const result = engine.interactHotspot('escritorio_ana', 'coffee_cup');
+    expect(result).toBeNull();
+  });
+
+  it('should execute take action and add item to inventory', () => {
+    const engine = new AdventureEngine(buildTestAdventure());
+    const result = engine.interactHotspot('cafetera');
+    expect(result).not.toBeNull();
+    expect(result!.text).toContain('USB drive');
+    expect(engine.hasItem('usb_drive')).toBe(true);
+  });
+
+  it('should return null for nonexistent hotspot', () => {
+    const engine = new AdventureEngine(buildTestAdventure());
+    const result = engine.interactHotspot('nonexistent');
+    expect(result).toBeNull();
+  });
+
+  // --- Character interaction ---
+
+  it('should return default talk text when no condition met', () => {
+    const engine = new AdventureEngine(buildTestAdventure());
+    const result = engine.interactCharacter('ana');
+    expect(result).not.toBeNull();
+    expect(result!.text).toContain('Have you seen the USB');
+  });
+
+  it('should return conditional talk text when condition met', () => {
+    const engine = new AdventureEngine(buildTestAdventure());
+    engine.executeActions([{ type: 'get', target: 'usb_drive' }]);
+    const result = engine.interactCharacter('ana');
+    expect(result).not.toBeNull();
+    expect(result!.text).toContain('You found it');
+  });
+
+  it('should execute actions from character talk', () => {
+    const engine = new AdventureEngine(buildTestAdventure());
+    engine.executeActions([{ type: 'get', target: 'usb_drive' }]);
+    engine.interactCharacter('carlos');
+    expect(engine.hasItem('server_key')).toBe(true);
+  });
+
+  it('should return null for nonexistent character', () => {
+    const engine = new AdventureEngine(buildTestAdventure());
+    const result = engine.interactCharacter('nobody');
+    expect(result).toBeNull();
+  });
+
+  // --- Exit interaction ---
+
+  it('should allow exit when no requires condition', () => {
+    const engine = new AdventureEngine(buildTestAdventure());
+    const result = engine.interactExit('pasillo_norte');
+    expect(result).not.toBeNull();
+    expect(engine.getState().currentScene).toBe('pasillo');
+  });
+
+  it('should block exit when requires condition not met', () => {
+    const engine = new AdventureEngine(buildTestAdventure());
+    // Navigate to pasillo first
+    engine.executeActions([{ type: 'go', target: 'pasillo' }]);
+    const result = engine.interactExit('server_room_este');
+    expect(result).not.toBeNull();
+    expect(result!.text).toBe('You need a key card to enter.');
+    expect(engine.getState().currentScene).toBe('pasillo');
+  });
+
+  it('should allow locked exit when player has required item', () => {
+    const engine = new AdventureEngine(buildTestAdventure());
+    engine.executeActions([{ type: 'go', target: 'pasillo' }]);
+    engine.executeActions([{ type: 'get', target: 'server_key' }]);
+    const result = engine.interactExit('server_room_este');
+    expect(result).not.toBeNull();
+    expect(engine.getState().currentScene).toBe('server_room');
+  });
+
+  it('should return null for nonexistent exit', () => {
+    const engine = new AdventureEngine(buildTestAdventure());
+    const result = engine.interactExit('nonexistent');
+    expect(result).toBeNull();
+  });
+
+  // --- Scene transitions ---
+
+  it('should change scene via go action', () => {
+    const engine = new AdventureEngine(buildTestAdventure());
+    engine.executeActions([{ type: 'go', target: 'pasillo' }]);
+    expect(engine.getState().currentScene).toBe('pasillo');
+    expect(engine.getCurrentScene().id).toBe('pasillo');
+  });
+
+  it('should ignore go action to nonexistent scene', () => {
+    const engine = new AdventureEngine(buildTestAdventure());
+    engine.executeActions([{ type: 'go', target: 'narnia' }]);
+    expect(engine.getState().currentScene).toBe('oficina');
+  });
+
+  // --- Win condition ---
+
+  it('should trigger win callback on win action', () => {
+    const engine = new AdventureEngine(buildTestAdventure());
+    const winHandler = vi.fn();
+    engine.onWin(winHandler);
+    engine.executeActions([{ type: 'win' }]);
+    expect(winHandler).toHaveBeenCalledOnce();
+  });
+
+  // --- Removed hotspots ---
+
+  it('should mark hotspot as removed via remove_hotspot action', () => {
+    const engine = new AdventureEngine(buildTestAdventure());
+    expect(engine.isHotspotRemoved('cafetera')).toBe(false);
+    engine.executeActions([{ type: 'remove_hotspot', target: 'cafetera' }]);
+    expect(engine.isHotspotRemoved('cafetera')).toBe(true);
+  });
+
+  it('should return null when interacting with removed hotspot', () => {
+    const engine = new AdventureEngine(buildTestAdventure());
+    engine.executeActions([{ type: 'remove_hotspot', target: 'cafetera' }]);
+    const result = engine.interactHotspot('cafetera');
+    expect(result).toBeNull();
+  });
+
+  // --- Event callbacks ---
+
+  it('should fire scene change callback', () => {
+    const engine = new AdventureEngine(buildTestAdventure());
+    const callback = vi.fn();
+    engine.onSceneChange(callback);
+    engine.executeActions([{ type: 'go', target: 'pasillo' }]);
+    expect(callback).toHaveBeenCalledWith('pasillo');
+  });
+
+  it('should fire inventory change callback on get', () => {
+    const engine = new AdventureEngine(buildTestAdventure());
+    const callback = vi.fn();
+    engine.onInventoryChange(callback);
+    engine.executeActions([{ type: 'get', target: 'usb_drive' }]);
+    expect(callback).toHaveBeenCalledWith(['usb_drive']);
+  });
+
+  it('should fire inventory change callback on remove', () => {
+    const engine = new AdventureEngine(buildTestAdventure());
+    engine.executeActions([{ type: 'get', target: 'usb_drive' }]);
+    const callback = vi.fn();
+    engine.onInventoryChange(callback);
+    engine.executeActions([{ type: 'remove', target: 'usb_drive' }]);
+    expect(callback).toHaveBeenCalledWith([]);
+  });
+
+  it('should support multiple callbacks', () => {
+    const engine = new AdventureEngine(buildTestAdventure());
+    const cb1 = vi.fn();
+    const cb2 = vi.fn();
+    engine.onWin(cb1);
+    engine.onWin(cb2);
+    engine.executeActions([{ type: 'win' }]);
+    expect(cb1).toHaveBeenCalledOnce();
+    expect(cb2).toHaveBeenCalledOnce();
+  });
+
+  // --- Queries ---
+
+  it('should return hotspot by id', () => {
+    const engine = new AdventureEngine(buildTestAdventure());
+    const hotspot = engine.getHotspot('cafetera');
+    expect(hotspot).toBeDefined();
+    expect(hotspot!.id).toBe('cafetera');
+  });
+
+  it('should return character by id', () => {
+    const engine = new AdventureEngine(buildTestAdventure());
+    const character = engine.getCharacter('ana');
+    expect(character).toBeDefined();
+    expect(character!.sprite).toBe('char_1');
+  });
+
+  it('should return exit by id', () => {
+    const engine = new AdventureEngine(buildTestAdventure());
+    const exit = engine.getExit('pasillo_norte');
+    expect(exit).toBeDefined();
+    expect(exit!.target).toBe('pasillo');
+  });
+
+  it('should return item by id', () => {
+    const engine = new AdventureEngine(buildTestAdventure());
+    const item = engine.getItem('usb_drive');
+    expect(item).toBeDefined();
+    expect(item!.name).toBe('USB Drive');
+  });
+
+  it('should return undefined for nonexistent item', () => {
+    const engine = new AdventureEngine(buildTestAdventure());
+    expect(engine.getItem('nonexistent')).toBeUndefined();
+  });
+
+  // --- Flag-based conditions ---
+
+  it('should evaluate flag conditions in character talk', () => {
+    const adventure = buildTestAdventure();
+    // Add a flag-based conditional talk to ana
+    adventure.scenes['oficina'].characters[0].talk.unshift({
+      condition: { type: 'flag', target: 'talked_to_carlos' },
+      text: 'I see you already talked to Carlos.',
+      actions: [],
+    });
+    const engine = new AdventureEngine(adventure);
+    engine.executeActions([{ type: 'set', target: 'talked_to_carlos' }]);
+    const result = engine.interactCharacter('ana');
+    expect(result).not.toBeNull();
+    expect(result!.text).toContain('talked to Carlos');
+  });
+
+  // --- Full playthrough ---
+
+  it('should complete the full Missing USB adventure', () => {
+    const engine = new AdventureEngine(buildTestAdventure());
+    const sceneChanges: string[] = [];
+    const inventoryChanges: string[][] = [];
+    let won = false;
+
+    engine.onSceneChange((id) => sceneChanges.push(id));
+    engine.onInventoryChange((inv) => inventoryChanges.push([...inv]));
+    engine.onWin(() => { won = true; });
+
+    // 1. Talk to Ana — default response (no USB yet)
+    let result = engine.interactCharacter('ana');
+    expect(result!.text).toContain('Have you seen the USB');
+
+    // 2. Pick up USB from cafetera
+    result = engine.interactHotspot('cafetera');
+    expect(result!.text).toContain('USB drive');
+    expect(engine.hasItem('usb_drive')).toBe(true);
+    expect(engine.isHotspotRemoved('cafetera')).toBe(true);
+
+    // 3. Talk to Ana again — now she knows we have USB
+    result = engine.interactCharacter('ana');
+    expect(result!.text).toContain('You found it');
+    expect(engine.hasFlag('talked_to_ana')).toBe(true);
+
+    // 4. Talk to Carlos — gives us server key
+    result = engine.interactCharacter('carlos');
+    expect(result!.text).toContain('take the server key');
+    expect(engine.hasItem('server_key')).toBe(true);
+
+    // 5. Use server key on door — go to server_room
+    result = engine.interactHotspot('puerta_server', 'server_key');
+    expect(result!.text).toContain('door slides open');
+    expect(engine.getState().currentScene).toBe('server_room');
+
+    // 6. Use USB on server — win!
+    result = engine.interactHotspot('servidor_principal', 'usb_drive');
+    expect(result!.text).toContain('deploy the fix');
+    expect(won).toBe(true);
+
+    // Verify callbacks were fired
+    expect(sceneChanges).toContain('server_room');
+    expect(inventoryChanges.length).toBeGreaterThanOrEqual(2);
+  });
+});

--- a/src/engine/AdventureEngine.ts
+++ b/src/engine/AdventureEngine.ts
@@ -1,0 +1,258 @@
+/**
+ * AdventureEngine — state machine for inventory, flags, and scene transitions.
+ *
+ * Manages the runtime state of a DSL v2 adventure: current scene, inventory,
+ * flags, removed hotspots, and event callbacks. Evaluates conditions and
+ * executes actions triggered by player interactions.
+ */
+
+import {
+  Action,
+  AdventureData,
+  CharacterDef,
+  Condition,
+  ConditionalInteraction,
+  ExitDef,
+  GameState,
+  HotspotDef,
+  InteractionResult,
+  ItemDef,
+  SceneDef,
+} from '../types/adventure-v2';
+
+type SceneChangeCallback = (sceneId: string) => void;
+type InventoryChangeCallback = (inventory: string[]) => void;
+type WinCallback = () => void;
+
+export class AdventureEngine {
+  private readonly adventure: AdventureData;
+  private state: GameState;
+
+  private sceneChangeCallbacks: SceneChangeCallback[] = [];
+  private inventoryChangeCallbacks: InventoryChangeCallback[] = [];
+  private winCallbacks: WinCallback[] = [];
+
+  constructor(adventure: AdventureData) {
+    this.adventure = adventure;
+    this.state = {
+      currentScene: adventure.startScene,
+      inventory: [],
+      flags: new Set<string>(),
+      removedHotspots: new Set<string>(),
+    };
+  }
+
+  // --- State ---
+
+  getState(): GameState {
+    return this.state;
+  }
+
+  getCurrentScene(): SceneDef {
+    return this.adventure.scenes[this.state.currentScene];
+  }
+
+  getInventory(): string[] {
+    return [...this.state.inventory];
+  }
+
+  hasItem(itemId: string): boolean {
+    return this.state.inventory.includes(itemId);
+  }
+
+  hasFlag(flagName: string): boolean {
+    return this.state.flags.has(flagName);
+  }
+
+  // --- Interactions ---
+
+  interactHotspot(hotspotId: string, withItem?: string): InteractionResult | null {
+    const hotspot = this.getHotspot(hotspotId);
+    if (!hotspot || this.isHotspotRemoved(hotspotId)) {
+      return null;
+    }
+
+    // If an item is provided, look for a matching use(item) conditional
+    if (withItem) {
+      const match = hotspot.use.find(
+        (u) => u.condition?.type === 'has' && u.condition.target === withItem
+      );
+      if (match) {
+        this.executeActions(match.actions);
+        return { text: match.text, actions: match.actions };
+      }
+      return null;
+    }
+
+    // If hotspot has a take action, execute it
+    if (hotspot.take) {
+      this.executeActions(hotspot.take.actions);
+      return { text: hotspot.take.text, actions: hotspot.take.actions };
+    }
+
+    // Fall back to default use (no condition)
+    const defaultUse = hotspot.use.find((u) => !u.condition);
+    if (defaultUse) {
+      this.executeActions(defaultUse.actions);
+      return { text: defaultUse.text, actions: defaultUse.actions };
+    }
+
+    return null;
+  }
+
+  interactCharacter(characterId: string): InteractionResult | null {
+    const character = this.getCharacter(characterId);
+    if (!character) {
+      return null;
+    }
+
+    // Find first matching conditional talk
+    for (const interaction of character.talk) {
+      if (interaction.condition && this.evaluateCondition(interaction.condition)) {
+        this.executeActions(interaction.actions);
+        return { text: interaction.text, actions: interaction.actions };
+      }
+    }
+
+    // Fall back to default talk (no condition)
+    const defaultTalk = character.talk.find((t) => !t.condition);
+    if (defaultTalk) {
+      this.executeActions(defaultTalk.actions);
+      return { text: defaultTalk.text, actions: defaultTalk.actions };
+    }
+
+    return null;
+  }
+
+  interactExit(exitId: string): InteractionResult | null {
+    const exit = this.getExit(exitId);
+    if (!exit) {
+      return null;
+    }
+
+    // Check requires condition
+    if (exit.requires && !this.hasItem(exit.requires)) {
+      return { text: exit.locked ?? 'You cannot go there yet.', actions: [] };
+    }
+
+    // Requirements met — execute go action
+    const goAction: Action = { type: 'go', target: exit.target };
+    this.executeActions([goAction]);
+    return { text: exit.look, actions: [goAction] };
+  }
+
+  // --- Actions ---
+
+  executeActions(actions: Action[]): void {
+    for (const action of actions) {
+      switch (action.type) {
+        case 'get':
+          if (action.target && !this.hasItem(action.target)) {
+            this.state.inventory.push(action.target);
+            this.notifyInventoryChange();
+          }
+          break;
+
+        case 'remove':
+          if (action.target) {
+            const index = this.state.inventory.indexOf(action.target);
+            if (index !== -1) {
+              this.state.inventory.splice(index, 1);
+              this.notifyInventoryChange();
+            }
+          }
+          break;
+
+        case 'go':
+          if (action.target && this.adventure.scenes[action.target]) {
+            this.state.currentScene = action.target;
+            this.notifySceneChange(action.target);
+          }
+          break;
+
+        case 'win':
+          this.notifyWin();
+          break;
+
+        case 'set':
+          if (action.target) {
+            this.state.flags.add(action.target);
+          }
+          break;
+
+        case 'remove_hotspot':
+          if (action.target) {
+            this.state.removedHotspots.add(action.target);
+          }
+          break;
+      }
+    }
+  }
+
+  // --- Queries ---
+
+  getHotspot(id: string): HotspotDef | undefined {
+    return this.getCurrentScene().hotspots.find((h) => h.id === id);
+  }
+
+  getCharacter(id: string): CharacterDef | undefined {
+    return this.getCurrentScene().characters.find((c) => c.id === id);
+  }
+
+  getExit(id: string): ExitDef | undefined {
+    return this.getCurrentScene().exits.find((e) => e.id === id);
+  }
+
+  getItem(id: string): ItemDef | undefined {
+    return this.adventure.items[id];
+  }
+
+  isHotspotRemoved(id: string): boolean {
+    return this.state.removedHotspots.has(id);
+  }
+
+  // --- Events ---
+
+  onSceneChange(callback: SceneChangeCallback): void {
+    this.sceneChangeCallbacks.push(callback);
+  }
+
+  onInventoryChange(callback: InventoryChangeCallback): void {
+    this.inventoryChangeCallbacks.push(callback);
+  }
+
+  onWin(callback: WinCallback): void {
+    this.winCallbacks.push(callback);
+  }
+
+  // --- Private helpers ---
+
+  private evaluateCondition(condition: Condition): boolean {
+    switch (condition.type) {
+      case 'has':
+        return this.hasItem(condition.target);
+      case 'flag':
+        return this.hasFlag(condition.target);
+      default:
+        return false;
+    }
+  }
+
+  private notifySceneChange(sceneId: string): void {
+    for (const cb of this.sceneChangeCallbacks) {
+      cb(sceneId);
+    }
+  }
+
+  private notifyInventoryChange(): void {
+    for (const cb of this.inventoryChangeCallbacks) {
+      cb(this.getInventory());
+    }
+  }
+
+  private notifyWin(): void {
+    for (const cb of this.winCallbacks) {
+      cb();
+    }
+  }
+}

--- a/src/types/adventure-v2.ts
+++ b/src/types/adventure-v2.ts
@@ -1,0 +1,80 @@
+/**
+ * TypeScript interfaces for VerbEngine DSL v2 data model.
+ *
+ * These types represent the structured adventure definition produced
+ * by the DSL v2 parser and consumed by the Phaser runtime.
+ */
+
+export interface ItemDef {
+  id: string;
+  name: string;
+  description: string;
+}
+
+export interface Condition {
+  type: 'has' | 'flag';
+  target: string;
+}
+
+export interface Action {
+  type: 'get' | 'remove' | 'go' | 'win' | 'set' | 'remove_hotspot';
+  target?: string;
+}
+
+export interface ConditionalInteraction {
+  condition?: Condition;
+  text: string;
+  actions: Action[];
+}
+
+export interface HotspotDef {
+  id: string;
+  position: [number, number];
+  look: string;
+  use: ConditionalInteraction[];
+  take?: { actions: Action[]; text: string };
+}
+
+export interface CharacterDef {
+  id: string;
+  position: [number, number];
+  sprite: string;
+  look: string;
+  talk: ConditionalInteraction[];
+}
+
+export interface ExitDef {
+  id: string;
+  position: [number, number];
+  target: string;
+  requires?: string;
+  locked?: string;
+  look: string;
+}
+
+export interface SceneDef {
+  id: string;
+  map: string;
+  hotspots: HotspotDef[];
+  characters: CharacterDef[];
+  exits: ExitDef[];
+}
+
+export interface AdventureData {
+  title: string;
+  startScene: string;
+  items: Record<string, ItemDef>;
+  scenes: Record<string, SceneDef>;
+}
+
+export interface GameState {
+  currentScene: string;
+  inventory: string[];
+  flags: Set<string>;
+  removedHotspots: Set<string>;
+}
+
+export interface InteractionResult {
+  text: string;
+  actions: Action[];
+}


### PR DESCRIPTION
## Summary
Closes #44

State machine managing inventory, flags, scene transitions, conditional interactions, and win condition.

## Changes
- `src/engine/AdventureEngine.ts` — full state machine with event callbacks
- `src/engine/AdventureEngine.test.ts` — 39 tests including full playthrough

## Test Plan
- `pnpm test` passes
- Full Missing USB adventure playthrough in tests