### PR TITLE
feat: FysoSceneBridge API for Fyso Teams integration

### DIFF
--- a/docs/fyso-teams-api.md
+++ b/docs/fyso-teams-api.md
@@ -1,0 +1,292 @@
+# Fyso Teams — API Reference
+
+## `createFysoGame(container, options?)`
+
+Factory function. Creates a Phaser game mounted inside `container` and returns a bridge for programmatic control. Only `FysoTeamsScene` is registered — no menu or adventure scenes are loaded.
+
+```ts
+function createFysoGame(
+  container: HTMLElement,
+  options?: FysoGameOptions,
+): { game: Phaser.Game; bridge: FysoSceneBridge }
+```
+
+### Parameters
+
+| Parameter   | Type             | Description |
+|-------------|------------------|-------------|
+| `container` | `HTMLElement`    | DOM element that will host the Phaser canvas. Phaser uses this as the `parent` in its config. |
+| `options`   | `FysoGameOptions` (optional) | Game configuration. All fields are optional; omitting the argument uses all defaults. |
+
+### Return value
+
+| Field    | Type               | Description |
+|----------|--------------------|-------------|
+| `game`   | `Phaser.Game`      | Raw Phaser game instance. Use for low-level access or to listen to Phaser lifecycle events. |
+| `bridge` | `FysoSceneBridge`  | Control interface for agents and camera. Prefer this over accessing the scene directly. |
+
+### Behaviour
+
+- Phaser is configured with `Phaser.Scale.RESIZE` — the canvas fills the container automatically.
+- Pixel-art rendering is enabled (`pixelArt: true`, `antialias: false`, `roundPixels: true`).
+- The scene starts on the `Phaser.Core.Events.READY` event with the provided options passed as init data.
+
+```ts
+const container = document.getElementById('game')!;
+const { game, bridge } = createFysoGame(container, {
+  zoom: 3,
+  basePath: '/static',
+});
+```
+
+---
+
+## `FysoGameOptions`
+
+Configuration object passed to `createFysoGame`.
+
+```ts
+interface FysoGameOptions {
+  zoom?: number;
+  basePath?: string;
+  mapData?: number[][];
+}
+```
+
+| Field      | Type         | Default | Description |
+|------------|--------------|---------|-------------|
+| `zoom`     | `number`     | `2`     | Initial camera zoom. Affects tile and character pixel sizes. Valid practical range: `1`–`4`. |
+| `basePath` | `string`     | `''`    | Prefix prepended to every asset URL. Useful when assets are not served from the root. Example: `'/static'` → loads `/static/assets/tiles/floor_carpet.png`. |
+| `mapData`  | `number[][]` | built-in 25x25 office | 2D array of tile type integers. Replaces the default office map entirely. See tile type reference below. |
+
+### Tile type values for `mapData`
+
+| Value | Tile |
+|-------|------|
+| `0` | Floor (walkable) |
+| `1` | Wall — plain |
+| `2` | Wall — window |
+| `3` | Desk |
+| `4` | Chair (walkable) |
+| `5` | Bookshelf |
+| `6` | Plant |
+| `7` | Coffee machine |
+
+Walkable tiles are `0` (floor) and `4` (chair). All other values block pathfinding.
+
+---
+
+## `AgentDef`
+
+Defines an agent at spawn time.
+
+```ts
+interface AgentDef {
+  id: string;
+  name: string;
+  sprite: string;
+  gridX: number;
+  gridY: number;
+  status?: AgentStatus;
+}
+```
+
+| Field    | Type          | Required | Description |
+|----------|---------------|----------|-------------|
+| `id`     | `string`      | Yes | Unique identifier. Used in all subsequent bridge calls. Duplicate IDs throw on `spawnAgent`. |
+| `name`   | `string`      | Yes | Display name shown in the label above the agent. |
+| `sprite` | `string`      | Yes | Spritesheet asset key. Built-in values: `'char_0'`, `'char_1'`, `'char_2'`, `'char_3'`. |
+| `gridX`  | `number`      | Yes | Column in the map grid (0-indexed from the top-left). |
+| `gridY`  | `number`      | Yes | Row in the map grid (0-indexed from the top-left). |
+| `status` | `AgentStatus` | No | Initial status badge. Defaults to `'idle'`. |
+
+---
+
+## `AgentStatus`
+
+```ts
+type AgentStatus = 'idle' | 'working' | 'talking' | 'walking' | 'done' | 'error';
+```
+
+| Value | Badge colour | Hex |
+|-------|-------------|-----|
+| `'idle'` | Grey | `#888888` |
+| `'working'` | Green | `#4caf50` |
+| `'talking'` | Blue | `#2196f3` |
+| `'walking'` | Orange | `#ff9800` |
+| `'done'` | Light green | `#8bc34a` |
+| `'error'` | Red | `#f44336` |
+
+The badge is a filled circle rendered above the agent's name label.
+
+---
+
+## `FysoSceneBridge`
+
+Thin adapter that proxies calls to `FysoTeamsScene`. The bridge holds no game state. `FysoTeamsScene` is the single source of truth for all agent positions and statuses.
+
+All methods throw `Error('Scene 'FysoTeamsScene' not found.')` if called before the scene is initialised by Phaser.
+
+---
+
+### `spawnAgent(def)`
+
+Adds an agent to the map.
+
+```ts
+spawnAgent(def: AgentDef): void
+```
+
+Throws if an agent with `def.id` is already present. The agent is placed at `(def.gridX, def.gridY)` and immediately plays its idle animation facing south.
+
+```ts
+bridge.spawnAgent({
+  id: 'bob',
+  name: 'Bob',
+  sprite: 'char_1',
+  gridX: 3,
+  gridY: 4,
+  status: 'working',
+});
+```
+
+---
+
+### `removeAgent(id)`
+
+Removes an agent from the map and destroys all its game objects (sprite, label, badge).
+
+```ts
+removeAgent(id: string): void
+```
+
+Safe to call with a non-existent `id` — no error is thrown. Any active movement tween is stopped before destruction.
+
+```ts
+bridge.removeAgent('bob');
+```
+
+---
+
+### `moveAgent(id, targetX, targetY)`
+
+Moves an agent to the given grid coordinates using EasyStar pathfinding.
+
+```ts
+moveAgent(id: string, targetX: number, targetY: number): void
+```
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `id` | `string` | Agent identifier. |
+| `targetX` | `number` | Target column. |
+| `targetY` | `number` | Target row. |
+
+Behaviour:
+- Does nothing if the agent is already moving.
+- Sets status to `'walking'` immediately.
+- On arrival, resets status to `'idle'`.
+- If no path exists, status resets to `'idle'` without moving.
+- Movement speed is 2.5 tiles per second.
+
+```ts
+bridge.moveAgent('alice', 10, 15);
+```
+
+---
+
+### `setAgentStatus(id, status)`
+
+Updates the agent's status badge colour without affecting movement or animations.
+
+```ts
+setAgentStatus(id: string, status: AgentStatus): void
+```
+
+Does nothing if `id` does not exist.
+
+```ts
+bridge.setAgentStatus('alice', 'working');
+```
+
+---
+
+### `showAgentMessage(id, text, duration?)`
+
+Displays a speech bubble above the agent.
+
+```ts
+showAgentMessage(id: string, text: string, duration?: number): void
+```
+
+| Parameter  | Type     | Default | Description |
+|------------|----------|---------|-------------|
+| `id`       | `string` | — | Agent identifier. |
+| `text`     | `string` | — | Message content displayed in the bubble. |
+| `duration` | `number` | `3000`  | Time in milliseconds before the bubble auto-dismisses. |
+
+While the bubble is visible, the agent's status is set to `'talking'`. When the duration elapses, the status reverts to whatever it was before `showAgentMessage` was called.
+
+Does nothing if `id` does not exist.
+
+```ts
+bridge.showAgentMessage('alice', 'PR is merged!', 5000);
+```
+
+---
+
+### `focusAgent(id)`
+
+Pans the camera to follow the given agent with smooth lerp (`0.1` on both axes).
+
+```ts
+focusAgent(id: string): void
+```
+
+The camera keeps following the agent as it moves. Camera follow is interrupted by keyboard arrow keys (WASD / arrows) or right-click drag.
+
+Does nothing if `id` does not exist.
+
+```ts
+bridge.focusAgent('alice');
+```
+
+---
+
+### `enableInput()`
+
+Re-enables pointer and keyboard input on the scene.
+
+```ts
+enableInput(): void
+```
+
+---
+
+### `disableInput()`
+
+Disables pointer and keyboard input on the scene. Useful when a host UI modal is open and you want to prevent accidental camera panning.
+
+```ts
+disableInput(): void
+```
+
+---
+
+### `destroy()`
+
+Destroys the Phaser game instance and releases all WebGL/canvas resources.
+
+```ts
+destroy(): void
+```
+
+Call this when the host component unmounts (e.g., React `useEffect` cleanup, Vue `onUnmounted`).
+
+```ts
+// React example
+useEffect(() => {
+  const { bridge } = createFysoGame(containerRef.current!);
+  return () => bridge.destroy();
+}, []);
+```

--- a/docs/fyso-teams-architecture.md
+++ b/docs/fyso-teams-architecture.md
@@ -1,0 +1,230 @@
+# Fyso Teams — Architecture
+
+## How FysoTeamsScene relates to the rest of VerbEngine
+
+VerbEngine's normal runtime runs `MenuScene` → `AdventureScene`, consuming `.verb` DSL files through `VerbParser`. `FysoTeamsScene` is a completely separate branch that shares only the Phaser dependency and the `BubbleText` engine helper.
+
+```
+verbengine/
+├── src/
+│   ├── scenes/
+│   │   ├── AdventureScene.ts     # normal adventure runtime
+│   │   ├── FysoTeamsScene.ts     # team visualisation scene (standalone)
+│   │   └── iso-math.ts           # shared coordinate utilities
+│   ├── engine/
+│   │   └── BubbleText.ts         # shared speech bubble primitive
+│   ├── api/
+│   │   ├── createFysoGame.ts     # factory — mounts a game with only FysoTeamsScene
+│   │   └── FysoSceneBridge.ts    # public control surface
+│   └── types/
+│       └── fyso-teams.ts         # AgentDef, AgentStatus, FysoGameOptions
+```
+
+`createFysoGame` registers only `FysoTeamsScene`. No DSL parsing, no adventure logic, no inventory system is loaded. The two runtimes can coexist in the same page by running in separate Phaser game instances, each in its own container element.
+
+---
+
+## Coordinate system
+
+The scene uses a standard 2:1 isometric projection. Internally there are two coordinate spaces:
+
+### Grid space
+
+Integer `(col, row)` pairs. Column 0, row 0 is the top corner of the diamond map. Columns increase to the right-bottom, rows increase to the left-bottom (when viewed on screen).
+
+Map data is stored as `number[row][col]`.
+
+### Screen space
+
+Pixel coordinates in world space (before camera transforms). The origin `(0, 0)` in world space corresponds to grid `(0, 0)`.
+
+Conversion formulas (from `iso-math.ts`):
+
+```
+screenX = (col - row) * (tileWidth  / 2)
+screenY = (col + row) * (tileHeight / 2)
+```
+
+Inverse (screen to grid, returning fractional values):
+
+```
+col = (screenX / halfW + screenY / halfH) / 2
+row = (screenY / halfH - screenX / halfW) / 2
+```
+
+Base tile dimensions before zoom: 32px wide, 16px tall (2:1 ratio). At the default zoom of `2` the rendered tile is 64x32 px.
+
+Character sprites are positioned with `origin(0.5, 1.0)` (horizontally centred, bottom-anchored) and offset downward by half a tile height so they stand at the front edge of the tile diamond.
+
+Depth sorting is painter's algorithm: `depth = row + col`. Decorations and agents add fractional offsets (`+0.5`, `+0.8`, `+0.9`, `+1.0`) to ensure consistent draw order within a cell.
+
+---
+
+## Agent lifecycle
+
+```
+spawnAgent()
+    |
+    v
+[sprite + label + badge created at gridX, gridY]
+    |
+    +--- setAgentStatus()  → redraws badge colour, status persists in AgentState
+    |
+    +--- showAgentMessage()
+    |       |
+    |       +→ status = 'talking' (temporary, reverts after duration)
+    |       +→ BubbleText.showNamedBubble()
+    |
+    +--- moveAgent()
+    |       |
+    |       +→ status = 'walking'
+    |       +→ EasyStar.findPath() (async, resolved in update loop)
+    |       +→ moveAgentAlongPath() (recursive tween chain)
+    |       +→ on arrival: status = 'idle'
+    |
+    +--- focusAgent()  → camera.startFollow(sprite)
+    |
+    v
+removeAgent()
+    |
+    +→ stop activeTween
+    +→ destroy sprite, label, badge
+    +→ delete from agents Map
+```
+
+`AgentState` is the internal record stored in `FysoTeamsScene.agents: Map<string, AgentState>`. It holds the current grid position, the Phaser game objects, the active tween reference, and the current status. `FysoSceneBridge` never caches this data; every call resolves the scene and reads from `AgentState` directly.
+
+---
+
+## Pathfinding (EasyStar)
+
+`EasyStar.js` is configured once in `create()`:
+
+- Grid: the full `mapData` array.
+- Acceptable (walkable) tiles: `0` (floor) and `4` (chair).
+- Diagonal movement: enabled.
+- Corner cutting: enabled.
+
+Path calculation is asynchronous and is driven by calling `this.easystar.calculate()` in the scene's `update()` loop. This spreads computation across frames and avoids frame drops on large maps.
+
+`moveAgent` rejects a move request silently if the agent `isMoving` is true. There is no move queue; the caller is responsible for sequencing moves.
+
+Movement along the computed path is a recursive tween chain (`moveAgentAlongPath`). Each step tweens the sprite (and its label and badge) from one grid position to the next over `(1 / 2.5) * 1000 = 400 ms`. On each frame of the tween, screen positions are rounded to integers to preserve pixel-art alignment.
+
+Direction is derived from `(dx, dy)` between consecutive path steps:
+
+| dx | dy | Direction |
+|----|----|-----------|
+| +  | +  | south |
+| -  | -  | north |
+| +  | -  | east |
+| -  | +  | west |
+| +  | 0  | east |
+| -  | 0  | west |
+| 0  | +  | south |
+| 0  | -  | north |
+
+West-facing animation reuses the east spritesheet row with `setFlipX(true)`.
+
+---
+
+## Rendering pipeline
+
+Each frame Phaser renders game objects sorted by their `depth` value. The rendering pipeline for a single frame:
+
+```
+1. Map tiles — pass 1 (floors and walls)
+   depth = row + col
+   Wall overlay drawn at depth + 0.3
+
+2. Map tiles — pass 2 (decorations: desks, plants, etc.)
+   depth = row + col + 0.5
+
+3. Agent sprites
+   depth = row + col + 0.8
+
+4. Agent name labels (Text)
+   depth = row + col + 0.9
+
+5. Agent status badges (Graphics circle)
+   depth = row + col + 1.0
+
+6. Speech bubbles (BubbleText — rendered as Text + Graphics)
+   not depth-sorted; always rendered on top
+```
+
+Tile images use `setScale(nanoScale)` where `nanoScale = tileWidth / 711`. The source tiles are 711px wide; this scale factor fits them exactly to the zoomed tile diamond.
+
+Character sprites use `setScale(zoom)` where `zoom` is the value from `FysoGameOptions`.
+
+---
+
+## Input isolation model
+
+The scene sets up two input handlers in `setupInput()`:
+
+- **Keyboard** (`ArrowLeft/Right/Up/Down`, `WASD`): pans the camera by `10 / zoom` pixels per keydown event. Calls `camera.stopFollow()` so manual pan breaks out of `focusAgent`.
+- **Right-click drag** (`pointer.buttons === 2`): pans by pointer velocity divided by zoom.
+- **Mouse wheel**: zooms the camera between `0.3` and `3.0` using `Phaser.Math.Clamp`.
+
+`enableInput()` / `disableInput()` toggle `this.input.enabled` and `this.input.keyboard.enabled`. This does not affect Phaser's internal scene lifecycle — only pointer and keyboard events on this scene are suppressed.
+
+---
+
+## How to extend
+
+### Custom map
+
+Pass a `mapData` 2D array in `FysoGameOptions`. The array must be rectangular (all rows the same length). Only values `0` and `4` are walkable; all other values block pathfinding.
+
+```ts
+const { bridge } = createFysoGame(container, {
+  mapData: [
+    [1, 1, 1, 1, 1],
+    [1, 0, 0, 0, 1],
+    [1, 0, 0, 0, 1],
+    [1, 1, 1, 1, 1],
+  ],
+});
+```
+
+If you add new tile type integers (e.g., `8`, `9`) they will render as floor tiles (no wall overlay, no decoration) because `drawMap` only has explicit branches for types `1`–`7`. To add new tile visuals, subclass or modify `FysoTeamsScene.drawMap`.
+
+### Custom sprites
+
+Pass the spritesheet key you preloaded in the host application:
+
+```ts
+// Preload in your own code before calling createFysoGame,
+// or add a preload hook to FysoTeamsScene.
+this.load.spritesheet('my-char', '/assets/my-char.png', {
+  frameWidth: 16,
+  frameHeight: 32,
+});
+
+bridge.spawnAgent({
+  id: 'custom',
+  name: 'Custom',
+  sprite: 'my-char',   // must match the key used in load.spritesheet
+  gridX: 5,
+  gridY: 5,
+});
+```
+
+The animation system expects the spritesheet to follow the same layout as the built-in characters: 7 columns x 3 rows, 16x32 px per frame, with south facing on row 0, north on row 1, and east on row 2. If your spritesheet differs, override `createCharacterAnimations` in a subclass.
+
+### Extending FysoSceneBridge
+
+`FysoSceneBridge` is not sealed. Add methods by extending the class and calling `this.getScene()` (currently private) — you will need to expose it or duplicate the accessor pattern:
+
+```ts
+class MyBridge extends FysoSceneBridge {
+  highlightTile(col: number, row: number): void {
+    // Access scene via the game reference you pass to super()
+    const scene = (this as any).game.scene.getScene('FysoTeamsScene');
+    // ... add a Graphics overlay
+  }
+}
+```
+
+For production use, the cleaner approach is to add the method to `FysoTeamsScene` and a corresponding delegation method to `FysoSceneBridge`, following the existing pattern.

--- a/docs/fyso-teams-quickstart.md
+++ b/docs/fyso-teams-quickstart.md
@@ -1,0 +1,57 @@
+# Fyso Teams — Quick Start
+
+FysoSceneBridge is a thin control layer over a self-contained Phaser 3 isometric scene designed to visualise teams of agents in a shared office space. You give it a DOM container, and it gives you back a bridge to spawn, move, and talk to agents programmatically.
+
+## Installation
+
+The integration ships as part of VerbEngine. Import directly from the package entry point:
+
+```ts
+import { createFysoGame } from 'verbengine/src/api';
+// or from the compiled bundle
+import { createFysoGame } from '@verbengine/fyso-teams';
+```
+
+Peer dependency: `phaser >= 3.60`.
+
+## Minimal working example
+
+```html
+<!-- index.html -->
+<div id="game" style="width: 800px; height: 600px;"></div>
+```
+
+```ts
+import { createFysoGame } from 'verbengine/src/api';
+
+// 1. Mount the game into a container element.
+const container = document.getElementById('game')!;
+const { bridge } = createFysoGame(container, { zoom: 2 });
+
+// 2. Spawn an agent at grid position (5, 5).
+//    The scene must be ready before calling bridge methods.
+//    Phaser fires 'ready' on the game object once all scenes are initialised.
+bridge.spawnAgent({
+  id: 'alice',
+  name: 'Alice',
+  sprite: 'char_0',
+  gridX: 5,
+  gridY: 5,
+  status: 'idle',
+});
+
+// 3. Move the agent to another tile via pathfinding.
+bridge.moveAgent('alice', 12, 8);
+
+// 4. Show a speech bubble for 4 seconds.
+bridge.showAgentMessage('alice', 'Hello, office!', 4000);
+```
+
+The built-in 25x25 office map loads automatically. Four character spritesheets (`char_0`–`char_3`) are included. No extra configuration is required for a local dev server that serves assets from `/assets/`.
+
+## What happens at startup
+
+1. `createFysoGame` instantiates a Phaser game with `FysoTeamsScene` as the only registered scene.
+2. On the `READY` event the scene starts and receives the options you passed.
+3. The scene preloads tiles and character spritesheets, draws the map, and initialises EasyStar pathfinding.
+4. Control returns to you through `FysoSceneBridge` — all subsequent calls go through the bridge.

--- a/package.json
+++ b/package.json
@@ -3,9 +3,25 @@
   "version": "0.2.0",
   "description": "AI-powered point-and-click adventure engine inspired by LucasArts classics",
   "type": "module",
+  "main": "dist/lib/verbengine.cjs",
+  "module": "dist/lib/verbengine.js",
+  "types": "dist/lib/index.d.ts",
+  "exports": {
+    ".": {
+      "import": "./dist/lib/verbengine.js",
+      "require": "./dist/lib/verbengine.cjs",
+      "types": "./dist/lib/index.d.ts"
+    }
+  },
+  "files": [
+    "dist/lib/",
+    "src/api/",
+    "src/types/fyso-teams.ts"
+  ],
   "scripts": {
     "dev": "vite",
     "build": "tsc && vite build",
+    "build:lib": "vite build --config vite.config.lib.ts",
     "test": "vitest run",
     "preview": "vite preview"
   },
@@ -13,6 +29,9 @@
   "author": "",
   "license": "MIT",
   "packageManager": "pnpm@10.30.2",
+  "peerDependencies": {
+    "phaser": "^3.90.0"
+  },
   "dependencies": {
     "easystarjs": "^0.4.4",
     "phaser": "^3.90.0"

--- a/src/api/FysoSceneBridge.test.ts
+++ b/src/api/FysoSceneBridge.test.ts
@@ -1,0 +1,222 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { FysoSceneBridge } from './FysoSceneBridge';
+import type { AgentDef } from '../types/fyso-teams';
+
+// ── Mock FysoTeamsScene ───────────────────────────────────────────
+
+function createMockScene() {
+  return {
+    spawnAgent: vi.fn(),
+    removeAgent: vi.fn(),
+    moveAgent: vi.fn(),
+    setAgentStatus: vi.fn(),
+    showAgentMessage: vi.fn(),
+    focusAgent: vi.fn(),
+    enableInput: vi.fn(),
+    disableInput: vi.fn(),
+  };
+}
+
+function createMockGame(scene: ReturnType<typeof createMockScene> | null = createMockScene()) {
+  return {
+    scene: {
+      getScene: vi.fn().mockReturnValue(scene),
+    },
+    destroy: vi.fn(),
+  };
+}
+
+// ── Helpers ───────────────────────────────────────────────────────
+
+const SCENE_KEY = 'FysoTeamsScene';
+
+function agentDef(overrides?: Partial<AgentDef>): AgentDef {
+  return {
+    id: 'agent-1',
+    name: 'Alice',
+    sprite: 'char_0',
+    gridX: 3,
+    gridY: 3,
+    ...overrides,
+  };
+}
+
+// ── Tests ─────────────────────────────────────────────────────────
+
+describe('FysoSceneBridge', () => {
+  let scene: ReturnType<typeof createMockScene>;
+  let game: ReturnType<typeof createMockGame>;
+  let bridge: FysoSceneBridge;
+
+  beforeEach(() => {
+    scene = createMockScene();
+    game = createMockGame(scene);
+    // Cast to satisfy TypeScript — we are testing bridge logic, not Phaser types
+    bridge = new FysoSceneBridge(game as unknown as import('phaser').Game, SCENE_KEY);
+  });
+
+  // ── spawnAgent ────────────────────────────────────────────────
+
+  describe('spawnAgent', () => {
+    it('delegates to scene.spawnAgent', () => {
+      const def = agentDef();
+      bridge.spawnAgent(def);
+      expect(scene.spawnAgent).toHaveBeenCalledOnce();
+      expect(scene.spawnAgent).toHaveBeenCalledWith(def);
+    });
+
+    it('passes agent id, name, sprite, and position', () => {
+      const def = agentDef({ id: 'bob', name: 'Bob', gridX: 5, gridY: 7 });
+      bridge.spawnAgent(def);
+      const call = scene.spawnAgent.mock.calls[0][0] as AgentDef;
+      expect(call.id).toBe('bob');
+      expect(call.name).toBe('Bob');
+      expect(call.gridX).toBe(5);
+      expect(call.gridY).toBe(7);
+    });
+
+    it('throws when scene is not found', () => {
+      const noSceneGame = createMockGame(null);
+      const badBridge = new FysoSceneBridge(
+        noSceneGame as unknown as import('phaser').Game,
+        SCENE_KEY,
+      );
+      expect(() => badBridge.spawnAgent(agentDef())).toThrow("Scene 'FysoTeamsScene' not found");
+    });
+  });
+
+  // ── removeAgent ───────────────────────────────────────────────
+
+  describe('removeAgent', () => {
+    it('delegates to scene.removeAgent with the given id', () => {
+      bridge.removeAgent('agent-1');
+      expect(scene.removeAgent).toHaveBeenCalledWith('agent-1');
+    });
+
+    it('is safe when called with a non-existent id (scene handles it)', () => {
+      // Bridge should pass through — scene is responsible for the no-op behaviour
+      expect(() => bridge.removeAgent('does-not-exist')).not.toThrow();
+      expect(scene.removeAgent).toHaveBeenCalledWith('does-not-exist');
+    });
+  });
+
+  // ── moveAgent ─────────────────────────────────────────────────
+
+  describe('moveAgent', () => {
+    it('delegates with correct id and coordinates', () => {
+      bridge.moveAgent('agent-1', 10, 12);
+      expect(scene.moveAgent).toHaveBeenCalledWith('agent-1', 10, 12);
+    });
+  });
+
+  // ── setAgentStatus ────────────────────────────────────────────
+
+  describe('setAgentStatus', () => {
+    it('delegates status update to scene', () => {
+      bridge.setAgentStatus('agent-1', 'working');
+      expect(scene.setAgentStatus).toHaveBeenCalledWith('agent-1', 'working');
+    });
+
+    it('can set every valid status', () => {
+      const statuses = ['idle', 'working', 'talking', 'walking', 'done', 'error'] as const;
+      for (const status of statuses) {
+        bridge.setAgentStatus('agent-1', status);
+      }
+      expect(scene.setAgentStatus).toHaveBeenCalledTimes(statuses.length);
+    });
+  });
+
+  // ── showAgentMessage ──────────────────────────────────────────
+
+  describe('showAgentMessage', () => {
+    it('delegates with text', () => {
+      bridge.showAgentMessage('agent-1', 'Hello!');
+      expect(scene.showAgentMessage).toHaveBeenCalledWith('agent-1', 'Hello!', undefined);
+    });
+
+    it('passes optional duration to scene', () => {
+      bridge.showAgentMessage('agent-1', 'Hi', 5000);
+      expect(scene.showAgentMessage).toHaveBeenCalledWith('agent-1', 'Hi', 5000);
+    });
+  });
+
+  // ── focusAgent ────────────────────────────────────────────────
+
+  describe('focusAgent', () => {
+    it('delegates to scene.focusAgent', () => {
+      bridge.focusAgent('agent-1');
+      expect(scene.focusAgent).toHaveBeenCalledWith('agent-1');
+    });
+  });
+
+  // ── enableInput / disableInput ────────────────────────────────
+
+  describe('input control', () => {
+    it('enableInput delegates to scene', () => {
+      bridge.enableInput();
+      expect(scene.enableInput).toHaveBeenCalledOnce();
+    });
+
+    it('disableInput delegates to scene', () => {
+      bridge.disableInput();
+      expect(scene.disableInput).toHaveBeenCalledOnce();
+    });
+  });
+
+  // ── destroy ───────────────────────────────────────────────────
+
+  describe('destroy', () => {
+    it('calls game.destroy(true)', () => {
+      bridge.destroy();
+      expect(game.destroy).toHaveBeenCalledWith(true);
+    });
+
+    it('does not interact with the scene on destroy', () => {
+      bridge.destroy();
+      expect(scene.spawnAgent).not.toHaveBeenCalled();
+      expect(scene.removeAgent).not.toHaveBeenCalled();
+    });
+  });
+
+  // ── Scene not found ───────────────────────────────────────────
+
+  describe('when scene is unavailable', () => {
+    let badBridge: FysoSceneBridge;
+
+    beforeEach(() => {
+      const noSceneGame = createMockGame(null);
+      badBridge = new FysoSceneBridge(
+        noSceneGame as unknown as import('phaser').Game,
+        SCENE_KEY,
+      );
+    });
+
+    it('throws on removeAgent', () => {
+      expect(() => badBridge.removeAgent('x')).toThrow("Scene 'FysoTeamsScene' not found");
+    });
+
+    it('throws on moveAgent', () => {
+      expect(() => badBridge.moveAgent('x', 0, 0)).toThrow();
+    });
+
+    it('throws on setAgentStatus', () => {
+      expect(() => badBridge.setAgentStatus('x', 'idle')).toThrow();
+    });
+
+    it('throws on showAgentMessage', () => {
+      expect(() => badBridge.showAgentMessage('x', 'hi')).toThrow();
+    });
+
+    it('throws on focusAgent', () => {
+      expect(() => badBridge.focusAgent('x')).toThrow();
+    });
+
+    it('throws on enableInput', () => {
+      expect(() => badBridge.enableInput()).toThrow();
+    });
+
+    it('throws on disableInput', () => {
+      expect(() => badBridge.disableInput()).toThrow();
+    });
+  });
+});

--- a/src/api/FysoSceneBridge.ts
+++ b/src/api/FysoSceneBridge.ts
@@ -1,0 +1,95 @@
+import Phaser from 'phaser';
+import type { FysoTeamsScene } from '../scenes/FysoTeamsScene';
+import type { AgentDef, AgentStatus } from '../types/fyso-teams';
+
+/**
+ * FysoSceneBridge — thin adapter between the host application and FysoTeamsScene.
+ *
+ * All methods delegate to FysoTeamsScene's public API. The bridge does not hold
+ * any game state; FysoTeamsScene is the single source of truth.
+ */
+export class FysoSceneBridge {
+  private game: Phaser.Game;
+  private sceneKey: string;
+
+  constructor(game: Phaser.Game, sceneKey: string) {
+    this.game = game;
+    this.sceneKey = sceneKey;
+  }
+
+  // ── Scene accessor ────────────────────────────────────────────
+
+  private getScene(): FysoTeamsScene {
+    const scene = this.game.scene.getScene(this.sceneKey) as FysoTeamsScene | null;
+    if (!scene) {
+      throw new Error(`Scene '${this.sceneKey}' not found.`);
+    }
+    return scene;
+  }
+
+  // ── Agent management ──────────────────────────────────────────
+
+  /**
+   * Spawn an agent on the map.
+   * Throws if an agent with the same id is already spawned.
+   */
+  spawnAgent(def: AgentDef): void {
+    this.getScene().spawnAgent(def);
+  }
+
+  /**
+   * Remove an agent from the map.
+   * Safe to call with a non-existent id — no error is thrown.
+   */
+  removeAgent(id: string): void {
+    this.getScene().removeAgent(id);
+  }
+
+  /**
+   * Move an agent to the given grid coordinates via pathfinding.
+   */
+  moveAgent(id: string, targetX: number, targetY: number): void {
+    this.getScene().moveAgent(id, targetX, targetY);
+  }
+
+  /**
+   * Update the status badge of an agent.
+   */
+  setAgentStatus(id: string, status: AgentStatus): void {
+    this.getScene().setAgentStatus(id, status);
+  }
+
+  /**
+   * Show a speech bubble above the agent.
+   * @param duration — ms before the bubble auto-dismisses (default 3000)
+   */
+  showAgentMessage(id: string, text: string, duration?: number): void {
+    this.getScene().showAgentMessage(id, text, duration);
+  }
+
+  /**
+   * Pan the camera to follow the given agent.
+   */
+  focusAgent(id: string): void {
+    this.getScene().focusAgent(id);
+  }
+
+  // ── Input control ─────────────────────────────────────────────
+
+  enableInput(): void {
+    this.getScene().enableInput();
+  }
+
+  disableInput(): void {
+    this.getScene().disableInput();
+  }
+
+  // ── Lifecycle ─────────────────────────────────────────────────
+
+  /**
+   * Destroy the Phaser game instance and release all resources.
+   */
+  destroy(): void {
+    this.game.destroy(true);
+  }
+}

--- a/src/api/createFysoGame.ts
+++ b/src/api/createFysoGame.ts
@@ -1,0 +1,49 @@
+import Phaser from 'phaser';
+import { FysoTeamsScene } from '../scenes/FysoTeamsScene';
+import { FysoSceneBridge } from './FysoSceneBridge';
+import type { FysoGameOptions } from '../types/fyso-teams';
+
+const SCENE_KEY = 'FysoTeamsScene';
+
+/**
+ * Create a self-contained Phaser game mounted inside `container` and return
+ * both the raw game instance and a FysoSceneBridge for programmatic control.
+ *
+ * Only FysoTeamsScene is registered — no MenuScene, no AdventureScene.
+ *
+ * @param container — The DOM element that will host the Phaser canvas.
+ * @param options   — Optional configuration (dimensions, zoom, basePath, mapData).
+ */
+export function createFysoGame(
+  container: HTMLElement,
+  options?: FysoGameOptions,
+): { game: Phaser.Game; bridge: FysoSceneBridge } {
+  const gameOptions: FysoGameOptions = options ?? {};
+
+  const config: Phaser.Types.Core.GameConfig = {
+    type: Phaser.AUTO,
+    parent: container,
+    backgroundColor: '#1a1a2e',
+    scale: {
+      mode: Phaser.Scale.RESIZE,
+      autoCenter: Phaser.Scale.CENTER_BOTH,
+    },
+    render: {
+      pixelArt: true,
+      antialias: false,
+      roundPixels: true,
+    },
+    scene: [FysoTeamsScene],
+  };
+
+  const game = new Phaser.Game(config);
+
+  // Pass options to the scene via scene init data when the scene starts.
+  game.events.once(Phaser.Core.Events.READY, () => {
+    game.scene.start(SCENE_KEY, gameOptions);
+  });
+
+  const bridge = new FysoSceneBridge(game, SCENE_KEY);
+
+  return { game, bridge };
+}

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -1,0 +1,3 @@
+export { createFysoGame } from './createFysoGame';
+export { FysoSceneBridge } from './FysoSceneBridge';
+export type { AgentDef, AgentStatus, FysoGameOptions } from '../types/fyso-teams';

--- a/src/scenes/FysoTeamsScene.ts
+++ b/src/scenes/FysoTeamsScene.ts
@@ -1,0 +1,579 @@
+import Phaser from 'phaser';
+import EasyStar from 'easystarjs';
+import { cartToIso, isoToCart } from './iso-math';
+import { BubbleText } from '../engine/BubbleText';
+import type { AgentDef, AgentStatus, FysoGameOptions } from '../types/fyso-teams';
+
+// ── Constants ─────────────────────────────────────────────────────
+
+/** Base tile diamond dimensions (2:1 ratio) */
+const BASE_TILE_WIDTH = 32;
+const BASE_TILE_HEIGHT = 16;
+
+/** Default zoom level */
+const DEFAULT_ZOOM = 2;
+
+/** Character frame size in the spritesheet */
+const CHAR_W = 16;
+const CHAR_H = 32;
+
+/** Movement speed in tiles/second */
+const MOVE_SPEED = 2.5;
+
+/** Animation frame duration in ms */
+const FRAME_DURATION_MS = 150;
+
+/** Spritesheet layout: 7 cols x 3 rows, each frame 16x32 */
+const SPRITE_COLS = 7;
+const WALK_CYCLE = [0, 1, 2, 1];
+
+/** Direction indices */
+const DIR_SOUTH = 0;
+const DIR_NORTH = 1;
+const DIR_EAST = 2;
+const DIR_WEST = 3;
+
+/** Walkable tile types */
+const WALKABLE_TILES = [0, 4];
+
+/** Status badge colors per status */
+const STATUS_COLORS: Record<AgentStatus, number> = {
+  idle: 0x888888,
+  working: 0x4caf50,
+  talking: 0x2196f3,
+  walking: 0xff9800,
+  done: 0x8bc34a,
+  error: 0xf44336,
+};
+
+/** Badge radius in pixels (pre-zoom) */
+const BADGE_RADIUS = 4;
+
+/** Depth layers */
+const BADGE_DEPTH_OFFSET = 1.0;
+const LABEL_DEPTH_OFFSET = 0.9;
+const SPRITE_DEPTH_OFFSET = 0.8;
+
+/**
+ * Default 25x25 office map.
+ * 0=floor, 1=wall-plain, 2=wall-window, 3=desk, 4=chair, 5=bookshelf, 6=plant, 7=coffee
+ */
+const DEFAULT_MAP_DATA: number[][] = [
+  [1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1],
+  [1,0,0,0,0,0,0,0,0,0,1,0,0,0,0,0,1,0,0,0,0,0,0,0,1],
+  [1,0,0,0,0,0,0,0,0,0,1,0,0,0,0,0,1,0,0,0,0,0,0,0,1],
+  [1,0,0,3,0,0,3,0,0,0,2,0,0,0,0,0,1,0,0,5,5,5,0,0,1],
+  [1,0,0,4,0,0,4,0,0,0,1,0,0,0,0,0,1,0,0,0,0,0,0,0,1],
+  [1,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,1,0,0,5,5,5,0,0,1],
+  [1,0,0,3,0,0,3,0,0,0,1,0,0,0,0,0,2,0,0,0,0,0,0,0,1],
+  [1,0,0,4,0,0,4,0,0,0,2,0,0,0,0,0,0,0,0,5,5,5,0,0,1],
+  [1,0,0,0,0,0,0,0,0,0,1,0,0,0,0,0,1,0,0,0,0,0,0,0,1],
+  [1,0,0,0,0,0,0,0,0,0,1,0,0,0,0,0,1,0,0,0,4,0,0,0,1],
+  [1,1,1,1,1,0,0,1,1,1,1,0,0,0,0,0,1,1,1,0,0,1,1,1,1],
+  [1,0,6,0,0,0,0,0,0,0,7,0,0,0,0,0,6,0,0,0,0,0,6,0,1],
+  [1,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,1],
+  [1,1,1,0,0,1,1,1,1,1,1,1,0,0,1,1,1,1,1,0,0,1,1,1,1],
+  [1,0,0,0,0,0,0,0,0,0,1,0,0,0,0,0,0,0,0,0,0,0,0,0,1],
+  [1,0,0,0,0,0,0,0,0,0,1,0,0,0,0,0,0,0,0,0,0,0,0,0,1],
+  [1,0,6,6,0,0,0,0,0,0,1,0,0,3,0,0,3,0,0,0,0,0,0,0,1],
+  [1,0,0,0,0,0,6,6,0,0,2,0,0,4,0,0,4,0,0,0,0,0,0,0,1],
+  [1,0,0,0,0,0,0,0,0,0,1,0,0,0,0,0,0,0,0,0,0,0,0,0,1],
+  [1,0,6,0,0,0,0,6,0,0,1,0,0,3,0,0,3,0,0,0,0,0,0,0,1],
+  [1,0,0,0,0,0,0,0,0,0,1,0,0,4,0,0,4,0,0,0,0,0,0,0,1],
+  [1,0,0,0,6,6,0,0,0,0,1,0,0,0,0,0,0,0,0,0,0,0,0,0,1],
+  [1,0,0,0,0,0,0,0,0,0,1,0,0,0,0,0,0,0,0,6,6,0,0,0,1],
+  [1,0,0,0,0,0,0,0,0,0,1,0,0,0,0,0,0,0,0,0,0,0,0,0,1],
+  [1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1],
+];
+
+
+// ── Agent state ───────────────────────────────────────────────────
+
+interface AgentState {
+  def: AgentDef;
+  sprite: Phaser.GameObjects.Sprite;
+  label: Phaser.GameObjects.Text;
+  badge: Phaser.GameObjects.Graphics;
+  status: AgentStatus;
+  currentX: number;
+  currentY: number;
+  isMoving: boolean;
+  activeTween?: Phaser.Tweens.Tween;
+}
+
+// ── Scene ─────────────────────────────────────────────────────────
+
+export class FysoTeamsScene extends Phaser.Scene {
+  private mapData: number[][] = DEFAULT_MAP_DATA;
+  private mapRows = 0;
+  private mapCols = 0;
+  private zoom = DEFAULT_ZOOM;
+  private basePath = '';
+
+  private tileWidth = 0;
+  private tileHeight = 0;
+  private nanoScale = 0;
+  private charScale = 0;
+
+  private easystar!: EasyStar.js;
+  private bubble!: BubbleText;
+  private agents: Map<string, AgentState> = new Map();
+
+  constructor() {
+    super({ key: 'FysoTeamsScene' });
+  }
+
+  // ── Lifecycle ─────────────────────────────────────────────────
+
+  init(data: FysoGameOptions): void {
+    this.mapData = data.mapData ?? DEFAULT_MAP_DATA;
+    this.mapRows = this.mapData.length;
+    this.mapCols = this.mapData[0]?.length ?? 0;
+    this.zoom = data.zoom ?? DEFAULT_ZOOM;
+    this.basePath = data.basePath ?? '';
+
+    this.tileWidth = BASE_TILE_WIDTH * this.zoom;
+    this.tileHeight = BASE_TILE_HEIGHT * this.zoom;
+    this.nanoScale = this.tileWidth / 711;
+    this.charScale = this.zoom;
+  }
+
+  preload(): void {
+    const base = this.basePath;
+    this.load.image('fyso-floor', `${base}/assets/tiles/floor_carpet.png`);
+    this.load.image('fyso-floor-wood', `${base}/assets/tiles/floor_wood_nano.png`);
+    this.load.image('fyso-wall-plain', `${base}/assets/tiles/wall_nano.png`);
+    this.load.image('fyso-wall-window', `${base}/assets/tiles/wall_window_nano.png`);
+    this.load.image('fyso-desk', `${base}/assets/tiles/desk.png`);
+    this.load.image('fyso-bookshelf', `${base}/assets/tiles/bookshelf_nano.png`);
+    this.load.image('fyso-plant', `${base}/assets/tiles/plant_nano.png`);
+    this.load.image('fyso-coffee', `${base}/assets/tiles/coffee_nano.png`);
+
+    const charSprites = ['char_0', 'char_1', 'char_2', 'char_3'];
+    for (const key of charSprites) {
+      this.load.spritesheet(key, `${base}/assets/characters/${key}.png`, {
+        frameWidth: CHAR_W,
+        frameHeight: CHAR_H,
+      });
+    }
+  }
+
+  create(): void {
+    this.cameras.main.setBackgroundColor('#2c2c3a');
+
+    this.bubble = new BubbleText(this);
+
+    this.setupPathfinder();
+    this.drawMap();
+    this.setupCamera();
+    this.setupInput();
+  }
+
+  update(): void {
+    this.easystar.calculate();
+  }
+
+  // ── Public API (called by FysoSceneBridge) ────────────────────
+
+  spawnAgent(def: AgentDef): void {
+    if (this.agents.has(def.id)) {
+      throw new Error(`Agent '${def.id}' is already spawned.`);
+    }
+
+    const status: AgentStatus = def.status ?? 'idle';
+
+    this.setupAgentAnimations(def.sprite);
+
+    const { x, y } = this.gridToScreen(def.gridX, def.gridY);
+    const sx = Math.round(x);
+    const sy = Math.round(y + this.tileHeight / 2);
+
+    const sprite = this.add.sprite(sx, sy, def.sprite, 0);
+    sprite.setScale(this.charScale);
+    sprite.setOrigin(0.5, 1.0);
+    sprite.setDepth(def.gridY + def.gridX + SPRITE_DEPTH_OFFSET);
+    sprite.play(`${def.sprite}-idle-south`);
+
+    const labelY = sy - CHAR_H * this.charScale - 5;
+    const label = this.add
+      .text(sx, labelY, def.name, {
+        fontFamily: 'monospace',
+        fontSize: '11px',
+        color: '#ffffff',
+        backgroundColor: '#00000088',
+        padding: { x: 3, y: 1 },
+      })
+      .setOrigin(0.5, 1.0)
+      .setDepth(def.gridY + def.gridX + LABEL_DEPTH_OFFSET);
+
+    const badge = this.add.graphics();
+    badge.setDepth(def.gridY + def.gridX + BADGE_DEPTH_OFFSET);
+    this.drawBadge(badge, sx, labelY - 10, status);
+
+    const state: AgentState = {
+      def: { ...def },
+      sprite,
+      label,
+      badge,
+      status,
+      currentX: def.gridX,
+      currentY: def.gridY,
+      isMoving: false,
+    };
+
+    this.agents.set(def.id, state);
+  }
+
+  removeAgent(id: string): void {
+    const agent = this.agents.get(id);
+    if (!agent) return;
+
+    agent.activeTween?.stop();
+    agent.sprite.destroy();
+    agent.label.destroy();
+    agent.badge.destroy();
+    this.agents.delete(id);
+  }
+
+  moveAgent(id: string, targetX: number, targetY: number): void {
+    const agent = this.agents.get(id);
+    if (!agent || agent.isMoving) return;
+
+    this.setAgentStatus(id, 'walking');
+
+    this.easystar.findPath(
+      agent.currentX,
+      agent.currentY,
+      targetX,
+      targetY,
+      (path) => {
+        if (!path || path.length < 2) {
+          this.setAgentStatus(id, 'idle');
+          return;
+        }
+        this.moveAgentAlongPath(agent, path.slice(1));
+      },
+    );
+  }
+
+  setAgentStatus(id: string, status: AgentStatus): void {
+    const agent = this.agents.get(id);
+    if (!agent) return;
+
+    agent.status = status;
+    const { x, y } = agent.sprite;
+    const labelY = y - CHAR_H * this.charScale - 5;
+    this.drawBadge(agent.badge, x, labelY - 10, status);
+  }
+
+  showAgentMessage(id: string, text: string, duration?: number): void {
+    const agent = this.agents.get(id);
+    if (!agent) return;
+
+    const previousStatus = agent.status;
+    const { x, y } = agent.sprite;
+    const bubbleY = y - CHAR_H * this.charScale - 20;
+    const ms = duration ?? 3000;
+
+    this.bubble.showNamedBubble(x, bubbleY, agent.def.name, text, ms);
+    this.setAgentStatus(id, 'talking');
+
+    this.time.delayedCall(ms, () => {
+      if (this.agents.has(id) && agent.status === 'talking') {
+        this.setAgentStatus(id, previousStatus);
+      }
+    });
+  }
+
+  focusAgent(id: string): void {
+    const agent = this.agents.get(id);
+    if (!agent) return;
+
+    this.cameras.main.startFollow(agent.sprite, true, 0.1, 0.1);
+  }
+
+  enableInput(): void {
+    this.input.enabled = true;
+    if (this.input.keyboard) this.input.keyboard.enabled = true;
+  }
+
+  disableInput(): void {
+    this.input.enabled = false;
+    if (this.input.keyboard) this.input.keyboard.enabled = false;
+  }
+
+  // ── Animations ────────────────────────────────────────────────
+
+  private setupAgentAnimations(spriteKey: string): void {
+    this.createCharacterAnimations(spriteKey);
+  }
+
+  private createCharacterAnimations(spriteKey: string): void {
+    const dirs = [
+      { name: 'south', row: 0 },
+      { name: 'north', row: 1 },
+      { name: 'east', row: 2 },
+      { name: 'west', row: 2 },
+    ];
+
+    for (const { name, row } of dirs) {
+      const walkKey = `${spriteKey}-walk-${name}`;
+      const idleKey = `${spriteKey}-idle-${name}`;
+
+      if (!this.anims.exists(walkKey)) {
+        this.anims.create({
+          key: walkKey,
+          frames: WALK_CYCLE.map((col) => ({
+            key: spriteKey,
+            frame: row * SPRITE_COLS + col,
+          })),
+          frameRate: Math.round(1000 / FRAME_DURATION_MS),
+          repeat: -1,
+        });
+      }
+
+      if (!this.anims.exists(idleKey)) {
+        this.anims.create({
+          key: idleKey,
+          frames: [{ key: spriteKey, frame: row * SPRITE_COLS + 0 }],
+          frameRate: 1,
+          repeat: 0,
+        });
+      }
+    }
+  }
+
+  // ── Pathfinder ────────────────────────────────────────────────
+
+  private setupPathfinder(): void {
+    this.easystar = new EasyStar.js();
+    this.easystar.setGrid(this.mapData);
+    this.easystar.setAcceptableTiles(WALKABLE_TILES);
+    this.easystar.enableDiagonals();
+    this.easystar.enableCornerCutting();
+  }
+
+  // ── Coordinate helpers ────────────────────────────────────────
+
+  private gridToScreen(gx: number, gy: number): { x: number; y: number } {
+    return cartToIso(gx, gy, this.tileWidth, this.tileHeight);
+  }
+
+  private screenToGrid(sx: number, sy: number): { col: number; row: number } | null {
+    const worldPoint = this.cameras.main.getWorldPoint(sx, sy);
+    const cart = isoToCart(worldPoint.x, worldPoint.y, this.tileWidth, this.tileHeight);
+    const col = Math.floor(cart.x);
+    const row = Math.floor(cart.y);
+
+    if (col < 0 || col >= this.mapCols || row < 0 || row >= this.mapRows) {
+      return null;
+    }
+    return { col, row };
+  }
+
+  // ── Map rendering ─────────────────────────────────────────────
+
+  private drawMap(): void {
+    const decoTextureMap: Record<number, string> = {
+      3: 'fyso-desk',
+      5: 'fyso-bookshelf',
+      6: 'fyso-plant',
+      7: 'fyso-coffee',
+    };
+
+    // Pass 1: floors and walls
+    for (let row = 0; row < this.mapRows; row++) {
+      for (let col = 0; col < this.mapCols; col++) {
+        const cellType = this.mapData[row][col];
+        const { x, y } = this.gridToScreen(col, row);
+        const sx = Math.round(x);
+        const sy = Math.round(y);
+        const depth = row + col;
+
+        if (cellType === 1 || cellType === 2) {
+          const floorImg = this.add.image(sx, sy, 'fyso-floor');
+          floorImg.setScale(this.nanoScale);
+          floorImg.setOrigin(0.5, 0);
+          floorImg.setDepth(depth);
+
+          const wallKey = cellType === 2 ? 'fyso-wall-window' : 'fyso-wall-plain';
+          const wallImg = this.add.image(sx, sy + this.tileHeight, wallKey);
+          wallImg.setScale(this.nanoScale);
+          wallImg.setOrigin(0.5, 1.0);
+          wallImg.setDepth(depth + 0.3);
+        } else {
+          const floorImg = this.add.image(sx, sy, 'fyso-floor');
+          floorImg.setScale(this.nanoScale);
+          floorImg.setOrigin(0.5, 0);
+          floorImg.setDepth(depth);
+        }
+      }
+    }
+
+    // Pass 2: decorations
+    for (let row = 0; row < this.mapRows; row++) {
+      for (let col = 0; col < this.mapCols; col++) {
+        const cellType = this.mapData[row][col];
+        const decoKey = decoTextureMap[cellType];
+        if (!decoKey) continue;
+
+        const { x, y } = this.gridToScreen(col, row);
+        const decoImg = this.add.image(
+          Math.round(x),
+          Math.round(y + this.tileHeight / 2),
+          decoKey,
+        );
+        decoImg.setScale(this.nanoScale);
+        decoImg.setOrigin(0.5, 0.5);
+        decoImg.setDepth(row + col + 0.5);
+      }
+    }
+  }
+
+  // ── Badge ─────────────────────────────────────────────────────
+
+  private drawBadge(
+    graphics: Phaser.GameObjects.Graphics,
+    x: number,
+    y: number,
+    status: AgentStatus,
+  ): void {
+    graphics.clear();
+    const color = STATUS_COLORS[status];
+    graphics.fillStyle(color, 1);
+    graphics.fillCircle(x, y, BADGE_RADIUS * this.charScale);
+  }
+
+  // ── Camera ────────────────────────────────────────────────────
+
+  private setupCamera(): void {
+    const topLeft = this.gridToScreen(0, 0);
+    const topRight = this.gridToScreen(this.mapCols, 0);
+    const bottomLeft = this.gridToScreen(0, this.mapRows);
+    const bottomRight = this.gridToScreen(this.mapCols, this.mapRows);
+
+    const minX = Math.min(topLeft.x, bottomLeft.x) - this.tileWidth;
+    const maxX = Math.max(topRight.x, bottomRight.x) + this.tileWidth;
+    const minY = Math.min(topLeft.y, topRight.y) - this.tileHeight * 2;
+    const maxY = Math.max(bottomLeft.y, bottomRight.y) + this.tileHeight * 2;
+
+    this.cameras.main.setBounds(minX, minY, maxX - minX, maxY - minY);
+    this.cameras.main.setZoom(1);
+    this.cameras.main.centerOn(0, 0);
+
+    this.input.on('wheel', (
+      _pointer: Phaser.Input.Pointer,
+      _gameObjects: unknown[],
+      _deltaX: number,
+      deltaY: number,
+    ) => {
+      const cam = this.cameras.main;
+      const newZoom = Phaser.Math.Clamp(cam.zoom - deltaY * 0.002, 0.3, 3);
+      cam.setZoom(newZoom);
+    });
+  }
+
+  // ── Input ─────────────────────────────────────────────────────
+
+  private setupInput(): void {
+    this.input.keyboard?.on('keydown', (event: KeyboardEvent) => {
+      const cam = this.cameras.main;
+      const panSpeed = 10 / cam.zoom;
+      if (event.key === 'ArrowLeft' || event.key === 'a') {
+        cam.stopFollow();
+        cam.scrollX -= panSpeed;
+      } else if (event.key === 'ArrowRight' || event.key === 'd') {
+        cam.stopFollow();
+        cam.scrollX += panSpeed;
+      } else if (event.key === 'ArrowUp' || event.key === 'w') {
+        cam.stopFollow();
+        cam.scrollY -= panSpeed;
+      } else if (event.key === 'ArrowDown' || event.key === 's') {
+        cam.stopFollow();
+        cam.scrollY += panSpeed;
+      }
+    });
+
+    this.input.on('pointermove', (pointer: Phaser.Input.Pointer) => {
+      // Drag-to-pan
+      if (pointer.isDown && pointer.buttons === 2) {
+        const cam = this.cameras.main;
+        cam.stopFollow();
+        cam.scrollX -= pointer.velocity.x / cam.zoom;
+        cam.scrollY -= pointer.velocity.y / cam.zoom;
+      }
+    });
+  }
+
+  // ── Agent movement ────────────────────────────────────────────
+
+  private moveAgentAlongPath(
+    agent: AgentState,
+    path: Array<{ x: number; y: number }>,
+  ): void {
+    if (path.length === 0) {
+      agent.isMoving = false;
+      const spriteKey = agent.def.sprite;
+      agent.sprite.play(`${spriteKey}-idle-south`);
+      const prevStatus = agent.status === 'walking' ? 'idle' : agent.status;
+      this.setAgentStatus(agent.def.id, prevStatus);
+      return;
+    }
+
+    agent.isMoving = true;
+    const next = path[0];
+    const remaining = path.slice(1);
+
+    const dx = next.x - agent.currentX;
+    const dy = next.y - agent.currentY;
+    const dir = this.getDirectionFromDelta(dx, dy);
+    const dirNames = ['south', 'north', 'east', 'west'];
+    const spriteKey = agent.def.sprite;
+
+    agent.sprite.setFlipX(dir === DIR_WEST);
+    const walkKey = `${spriteKey}-walk-${dirNames[dir]}`;
+    if (agent.sprite.anims.currentAnim?.key !== walkKey) {
+      agent.sprite.play(walkKey);
+    }
+
+    const from = this.gridToScreen(agent.currentX, agent.currentY);
+    const to = this.gridToScreen(next.x, next.y);
+    const charOffsetY = this.tileHeight / 2;
+    const stepDuration = (1 / MOVE_SPEED) * 1000;
+    const tweenTarget = { x: from.x, y: from.y + charOffsetY };
+
+    agent.activeTween = this.tweens.add({
+      targets: tweenTarget,
+      x: to.x,
+      y: to.y + charOffsetY,
+      duration: stepDuration,
+      ease: 'Linear',
+      onUpdate: () => {
+        agent.sprite.setPosition(Math.round(tweenTarget.x), Math.round(tweenTarget.y));
+        const labelY = Math.round(tweenTarget.y - CHAR_H * this.charScale - 5);
+        agent.label.setPosition(Math.round(tweenTarget.x), labelY);
+        this.drawBadge(agent.badge, Math.round(tweenTarget.x), labelY - 10, agent.status);
+      },
+      onComplete: () => {
+        agent.currentX = next.x;
+        agent.currentY = next.y;
+        const newDepth = agent.currentY + agent.currentX;
+        agent.sprite.setDepth(newDepth + SPRITE_DEPTH_OFFSET);
+        agent.label.setDepth(newDepth + LABEL_DEPTH_OFFSET);
+        agent.badge.setDepth(newDepth + BADGE_DEPTH_OFFSET);
+        this.moveAgentAlongPath(agent, remaining);
+      },
+    });
+  }
+
+  private getDirectionFromDelta(dx: number, dy: number): number {
+    if (dx > 0 && dy > 0) return DIR_SOUTH;
+    if (dx < 0 && dy < 0) return DIR_NORTH;
+    if (dx > 0 && dy < 0) return DIR_EAST;
+    if (dx < 0 && dy > 0) return DIR_WEST;
+    if (dx > 0) return DIR_EAST;
+    if (dx < 0) return DIR_WEST;
+    if (dy > 0) return DIR_SOUTH;
+    return DIR_NORTH;
+  }
+}

--- a/src/types/fyso-teams.ts
+++ b/src/types/fyso-teams.ts
@@ -1,0 +1,29 @@
+/**
+ * Type definitions for Fyso Teams integration.
+ */
+
+export type AgentStatus =
+  | 'idle'
+  | 'working'
+  | 'talking'
+  | 'walking'
+  | 'done'
+  | 'error';
+
+export interface AgentDef {
+  id: string;
+  name: string;
+  sprite: string;
+  gridX: number;
+  gridY: number;
+  status?: AgentStatus;
+}
+
+export interface FysoGameOptions {
+  /** Camera zoom level (default: 2) */
+  zoom?: number;
+  /** Asset base path (default: '') */
+  basePath?: string;
+  /** Injectable map data (default: built-in office map) */
+  mapData?: number[][];
+}

--- a/vite.config.lib.ts
+++ b/vite.config.lib.ts
@@ -1,0 +1,23 @@
+import { defineConfig } from 'vite';
+import { resolve } from 'path';
+
+export default defineConfig({
+  build: {
+    lib: {
+      entry: resolve(__dirname, 'src/api/index.ts'),
+      name: 'verbengine',
+      fileName: 'verbengine',
+      formats: ['es', 'cjs'],
+    },
+    outDir: 'dist/lib',
+    emptyOutDir: true,
+    rollupOptions: {
+      external: ['phaser'],
+      output: {
+        globals: {
+          phaser: 'Phaser',
+        },
+      },
+    },
+  },
+});


### PR DESCRIPTION
## Summary
- Imperative bridge API (`createFysoGame`, `FysoSceneBridge`) for React to control an isometric Phaser scene
- New `FysoTeamsScene` with dynamic agent registry, pathfinding, status badges, and speech bubbles
- Library build config (`vite.config.lib.ts`) producing ESM + CJS with Phaser as peer dependency
- Layered docs: quickstart, API reference, architecture

Closes #71

## Changes
- `src/api/` — `createFysoGame`, `FysoSceneBridge`, barrel export, 22 unit tests
- `src/scenes/FysoTeamsScene.ts` — externally-driven isometric scene (no adventure logic)
- `src/types/fyso-teams.ts` — `AgentDef`, `AgentStatus`, `FysoGameOptions`
- `vite.config.lib.ts` — library build (28KB ESM, 20KB CJS)
- `package.json` — library exports, peer deps, `build:lib` script
- `docs/` — quickstart, API reference, architecture docs

## Test plan
- [ ] `pnpm test` — 22 new bridge tests pass, no regressions
- [ ] `npx tsc --noEmit` — compiles clean
- [ ] `pnpm build:lib` — produces `dist/lib/verbengine.js` + `.cjs`
- [ ] Code review passed (2 critical, 5 major fixes applied)
- [ ] QA passed (11/11 acceptance criteria)

🤖 Generated with [Claude Code](https://claude.com/claude-code)